### PR TITLE
Fixes #9: Use getters instead of instance vars

### DIFF
--- a/lib/chef-vault.rb
+++ b/lib/chef-vault.rb
@@ -37,10 +37,10 @@ class ChefVault
   end
 
   def user(username)
-    ChefVault::User.new(@data_bag, username, @chef_config_file)
+    ChefVault::User.new(data_bag, username, chef_config_file)
   end
 
   def certificate(name)
-    ChefVault::Certificate.new(@data_bag, name, @chef_config_file)
+    ChefVault::Certificate.new(data_bag, name, chef_config_file)
   end
 end


### PR DESCRIPTION
Replace `@data_bag` and `@chef_config_file` instance vars with getters generated by `attr_accessor` per POODR
