### PR TITLE
move the compat include into the lazy-load

### DIFF
--- a/lib/chef/knife/DecryptCert.rb
+++ b/lib/chef/knife/DecryptCert.rb
@@ -20,15 +20,15 @@ class DecryptCert < Chef::Knife
     require 'chef/search/query'
     require 'json'
     require File.expand_path('../compat', __FILE__)
+    include ChefVault::Compat
   end
-  include ChefVault::Compat
 
   banner "knife decrypt cert --name NAME"
 
   option :name,
     :short => '-N NAME',
     :long => '--name NAME',
-    :description => 'Certificate data bag name' 
+    :description => 'Certificate data bag name'
 
   def run
     unless config[:name]

--- a/lib/chef/knife/DecryptPassword.rb
+++ b/lib/chef/knife/DecryptPassword.rb
@@ -20,15 +20,15 @@ class DecryptPassword < Chef::Knife
     require 'chef/search/query'
     require 'json'
     require File.expand_path('../compat', __FILE__)
+    include ChefVault::Compat
   end
-  include ChefVault::Compat
 
   banner "knife decrypt password --username USERNAME"
 
   option :username,
     :short => '-U USERNAME',
     :long => '--username USERNAME',
-    :description => 'username of account to encrypt' 
+    :description => 'username of account to encrypt'
 
   def run
     unless config[:username]

--- a/lib/chef/knife/EncryptCert.rb
+++ b/lib/chef/knife/EncryptCert.rb
@@ -19,15 +19,15 @@ class EncryptCert < Chef::Knife
   deps do
     require 'chef/search/query'
     require File.expand_path('../compat', __FILE__)
+    include ChefVault::Compat
   end
-  include ChefVault::Compat
 
   banner "knife encrypt cert --search SEARCH --cert CERT --password PASSWORD --name NAME --admins ADMINS"
 
   option :search,
     :short => '-S SEARCH',
     :long => '--search SEARCH',
-    :description => 'node search for nodes to encrypt to' 
+    :description => 'node search for nodes to encrypt to'
 
   option :cert,
     :short => '-C CERT',
@@ -42,12 +42,12 @@ class EncryptCert < Chef::Knife
   option :password,
     :short => '-P PASSWORD',
     :long => '--password PASSWORD',
-    :description => 'optional pfx password' 
+    :description => 'optional pfx password'
 
   option :name,
     :short => '-N NAME',
     :long => '--name NAME',
-    :description => 'optional data bag name' 
+    :description => 'optional data bag name'
 
   def run
     unless config[:search]
@@ -79,7 +79,7 @@ class EncryptCert < Chef::Knife
     file_to_encrypt = config[:cert]
     contents = open(file_to_encrypt, "rb").read
     name = config[:name] ? config[:name].gsub(".", "_") : File.basename(file_to_encrypt, ".*").gsub(".", "_")
-    
+
     current_dbi = Hash.new
     current_dbi_keys = Hash.new
     if File.exists?("#{data_bag_path}/#{name}_keys.json") && File.exists?("#{data_bag_path}/#{name}.json")
@@ -109,7 +109,7 @@ class EncryptCert < Chef::Knife
         puts("WARNING: Caught exception: #{node_error.message} while processing #{client}, so skipping...")
       end
     end
-    
+
     # Get the public keys for the admin users, skipping users already in the data bag
     public_keys << admins.split(/[\s,]+/).map do |user|
       begin
@@ -126,7 +126,7 @@ class EncryptCert < Chef::Knife
     end
 
     if public_keys.length == 0
-      puts "A node search for #{node_search} returned no results" 
+      puts "A node search for #{node_search} returned no results"
       exit 1
     end
 
@@ -176,8 +176,8 @@ class EncryptCert < Chef::Knife
 
     private_key = OpenSSL::PKey::RSA.new(open(Chef::Config[:client_key]).read())
     key = File.exists?("#{data_bag_path}/#{dbi}_keys.json") ? JSON.parse(open("#{data_bag_path}/#{dbi}_keys.json").read()) : nil
-    
-    begin      
+
+    begin
       private_key.private_decrypt(Base64.decode64(key[Chef::Config[:node_name]]))
     rescue
       nil

--- a/lib/chef/knife/EncryptPassword.rb
+++ b/lib/chef/knife/EncryptPassword.rb
@@ -19,20 +19,20 @@ class EncryptPassword < Chef::Knife
   deps do
     require 'chef/search/query'
     require File.expand_path('../compat', __FILE__)
+    include ChefVault::Compat
   end
-  include ChefVault::Compat
 
   banner "knife encrypt password --search SEARCH --username USERNAME --password PASSWORD --admins ADMINS"
 
   option :search,
     :short => '-S SEARCH',
     :long => '--search SEARCH',
-    :description => 'node search for nodes to encrypt for' 
+    :description => 'node search for nodes to encrypt for'
 
   option :username,
     :short => '-U USERNAME',
     :long => '--username USERNAME',
-    :description => 'username of account to encrypt' 
+    :description => 'username of account to encrypt'
 
   option :password,
     :short => '-P PASSWORD',
@@ -61,7 +61,7 @@ class EncryptPassword < Chef::Knife
       puts("You must supply either -A or --admins")
       exit 1
     end
-  
+
     extend_context_object(self)
 
     data_bag = "passwords"
@@ -107,7 +107,7 @@ class EncryptPassword < Chef::Knife
         puts("WARNING: Caught exception: #{node_error.message} while processing #{client}, so skipping...")
       end
     end
-    
+
     # Get the public keys for the admin users, skipping users already in the data bag
     public_keys << admins.split(/[\s,]+/).map do |user|
       begin
@@ -124,7 +124,7 @@ class EncryptPassword < Chef::Knife
     end
 
     if public_keys.length == 0
-      puts "A node search for #{node_search} returned no results" 
+      puts "A node search for #{node_search} returned no results"
       exit 1
     end
 
@@ -173,8 +173,8 @@ class EncryptPassword < Chef::Knife
 
     private_key = OpenSSL::PKey::RSA.new(open(Chef::Config[:client_key]).read())
     key = File.exists?("#{data_bag_path}/#{dbi}_keys.json") ? JSON.parse(open("#{data_bag_path}/#{dbi}_keys.json").read()) : nil
-    
-    begin      
+
+    begin
       private_key.private_decrypt(Base64.decode64(key[Chef::Config[:node_name]]))
     rescue
       nil


### PR DESCRIPTION
before this patch when trying to use knife-vault  knife encrypt would throw errors because a method was added to compat.rb that assumes the class has been loaded:

```
$ knife 
/home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-vault-1.2.3/lib/chef/knife/EncryptCert.rb:23:in `<class:EncryptCert>': uninitialized constant EncryptCert::ChefVault (NameError)
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-vault-1.2.3/lib/chef/knife/EncryptCert.rb:18:in `<top (required)>'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/knife/core/subc
ommand_loader.rb:37:in `load'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/knife/core/subcommand_loader.rb:37:in `block in load_commands'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/knife/core/subcommand_loader.rb:37:in `each'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/knife/core/subcommand_loader.rb:37:in `load_commands'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/knife.rb:119:in `load_commands'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/knife.rb:167:in `run'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/lib/chef/application/knife.rb:123:in `run'
  from /home/user/.rbenv/versions/1.9.3-p429/lib/ruby/gems/1.9.1/gems/chef-11.4.4/bin/knife:25:in `<top (required)>'
  from /home/user/.rbenv/versions/1.9.3-p429/bin/knife:23:in `load'

```

So I moved the include into the lazily loaded `dep` method block. 

P.S. Sorry for the whitespace changes my editor is tuned to destroy empty whitespace at the end of lines :D
`?w=1` takes care of it  
