### PR TITLE
Fix: open locked file on windows during data_bag update

### DIFF
--- a/lib/chef/knife/EncryptPassword.rb
+++ b/lib/chef/knife/EncryptPassword.rb
@@ -81,8 +81,8 @@ class EncryptPassword < Chef::Knife
     current_dbi = Hash.new
     current_dbi_keys = Hash.new
     if File.exists?("#{data_bag_path}/#{username}_keys.json") && File.exists?("#{data_bag_path}/#{username}.json")
-      current_dbi_keys = JSON.parse(open("#{data_bag_path}/#{username}_keys.json").read())
-      current_dbi = JSON.parse(open("#{data_bag_path}/#{username}.json").read())
+      current_dbi_keys = JSON.parse(File.open("#{data_bag_path}/#{username}_keys.json"){ |file| file.read() })
+      current_dbi = JSON.parse(File.open("#{data_bag_path}/#{username}.json"){ |file| file.read() })
 
       unless equal?(data_bag, username, "password", password)
         puts("FATAL: Password in #{data_bag_path}/#{username}.json does not match password supplied!")
@@ -142,7 +142,7 @@ class EncryptPassword < Chef::Knife
     # Delete existing keys data bag and rewrite the whole bag from memory
     puts("INFO: Writing #{data_bag_path}/#{username}_keys.json...")
     File.delete("#{data_bag_path}/#{username}_keys.json") if File.exists?("#{data_bag_path}/#{username}_keys.json")
-    File.open("#{data_bag_path}/#{username}_keys.json",'w').write(JSON.pretty_generate(enc_db_key_dbi))
+    File.open("#{data_bag_path}/#{username}_keys.json",'w'){ |file| file.write(JSON.pretty_generate(enc_db_key_dbi)) }
 
     # If the existing password bag does not exist, write it out with the correct password
     # Otherwise leave the existing bag alone
@@ -152,7 +152,7 @@ class EncryptPassword < Chef::Knife
       edbi = Chef::EncryptedDataBagItem.encrypt_data_bag_item(dbi, data_bag_shared_key)
 
       puts("INFO: Writing #{data_bag_path}/#{username}.json...")
-      open("#{data_bag_path}/#{username}.json",'w').write(JSON.pretty_generate(edbi))
+      File.open("#{data_bag_path}/#{username}.json",'w'){ |file| file.write(JSON.pretty_generate(edbi)) }
     end
 
     puts("INFO: Successfully wrote #{data_bag_path}/#{username}.json & #{data_bag_path}/#{username}_keys.json!")
@@ -172,7 +172,7 @@ class EncryptPassword < Chef::Knife
     data_bag_path = "./data_bags/#{db}"
 
     private_key = OpenSSL::PKey::RSA.new(open(Chef::Config[:client_key]).read())
-    key = File.exists?("#{data_bag_path}/#{dbi}_keys.json") ? JSON.parse(open("#{data_bag_path}/#{dbi}_keys.json").read()) : nil
+    key = File.exists?("#{data_bag_path}/#{dbi}_keys.json") ? JSON.parse(File.open("#{data_bag_path}/#{dbi}_keys.json"){ |file| file.read() }) : nil
     
     begin      
       private_key.private_decrypt(Base64.decode64(key[Chef::Config[:node_name]]))


### PR DESCRIPTION
The current open() calls were locking the file and causing the write() to fail on Windows. New files were not affected by this issue.
