### PR TITLE
Addresses #46, use a larger default key size

### DIFF
--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -131,8 +131,8 @@ class ChefVault::Item < Chef::DataBagItem
     reload_raw_data
   end
 
-  def generate_secret
-    OpenSSL::PKey::RSA.new(245).to_pem.lines.to_a[1..-2].join
+  def generate_secret(key_size=2048)
+    OpenSSL::PKey::RSA.new(key_size).to_pem.lines.to_a[1..-2].join
   end
 
   def []=(key, value)


### PR DESCRIPTION
Default size will be 2048, though this is now parameterized and one
could pass the key size into the generate_secret method in a later
refactoring.
