### PR TITLE
Fixes #56: Typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Depending on your system's configuration, you may need to run this command with 
 ## KNIFE COMMANDS:
 See KNIFE_EXAMPLES.md for examples of commands
 
-NOTE: chef-vault 1.0 knife commands are not support!  Please use chef-vault 2.0 commands.
+NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.0 commands.
 
 ### Encrypt
 


### PR DESCRIPTION
This is a pretty minor change.

The readme should say that knife commands are not support, but should say supported: 

`NOTE: chef-vault 1.0 knife commands are not support! Please use chef-vault 2.0 commands.`

but should say

`NOTE: chef-vault 1.0 knife commands are not supported! Please use chef-vault 2.0 commands.`
