### PR TITLE
Issue #62: Allow for printing entire chef-vault'ed databag

### DIFF
--- a/lib/chef/knife/Decrypt.rb
+++ b/lib/chef/knife/Decrypt.rb
@@ -30,14 +30,14 @@ class Decrypt < Chef::Knife
   option :mode,
     :short => '-M MODE',
     :long => '--mode MODE',
-    :description => 'Chef mode to run in default - solo'  
+    :description => 'Chef mode to run in default - solo'
 
   def run
     vault = @name_args[0]
     item = @name_args[1]
     values = @name_args[2]
 
-    if vault && item && values
+    if vault && item
       set_mode(config[:mode])
 
       print_values(vault, item, values)
@@ -54,11 +54,15 @@ class Decrypt < Chef::Knife
   def print_values(vault, item, values)
     vault_item = ChefVault::Item.load(vault, item)
 
-    puts "#{vault}/#{item}"
+    if values
+      puts "#{vault}/#{item}"
 
-    values.split(",").each do |value|
-      value.strip! # remove white space
-      puts("\t#{value}: #{vault_item[value]}")
+      values.split(",").each do |value|
+        value.strip! # remove white space
+        puts("\t#{value}: #{vault_item[value]}")
+      end
+    else
+      output(vault_item.raw_data)
     end
-  end    
+  end
 end


### PR DESCRIPTION
Made values optional for knife decrypt.  If values isn't specified, it
will print the contents of the data bag formatted per standard knife
output formatters.
