### PR TITLE
Issue 50: Use standard chef/knife formatting for all knife decrypt output

### DIFF
--- a/KNIFE_EXAMPLES.md
+++ b/KNIFE_EXAMPLES.md
@@ -1,7 +1,7 @@
 # knife examples
 
 ## encrypt
-knife encrypt [create|update|remove|delete] [VAULT] [ITEM] [VALUES]
+knife encrypt [create|update|remove|delete] VAULT ITEM VALUES
 
 These are the commands that are used to take data in json format and encrypt that data into chef-vault style encrypted data bags in chef.
 
@@ -20,7 +20,7 @@ Creat a vault called passwords and put an item called root in it with the given 
 
 Creat a vault called passwords and put an item called root in it with the given values for username and password encrypted for admins admin1 & admin2
 
-    knife encrypt create passwords root "{username: 'root', password: 'mypassword'}" -A "admin1,admin2"    
+    knife encrypt create passwords root "{username: 'root', password: 'mypassword'}" -A "admin1,admin2"
 
 Note: A JSON file can be used in place of specifying the values on the command line, see global options below for details
 
@@ -134,13 +134,18 @@ Rotate the shared key for the vault passwords and item root.  The shared key is 
 </table>
 
 ## decrypt
-knife decrypt [VAULT] [ITEM] [VALUES]
+knife decrypt VAULT ITEM [VALUES]
 
 These are the commands that are used to take a chef-vault encrypted item and decrypt the requested values.
 
 * Vault - This is the name of the vault in which to store the encrypted item.  This is analogous to a chef data bag name
 * Item - The name of the item going in to the vault.  This is analogous to a chef data bag item id
 * Values - This is a comma list of values to decrypt from the vault item.  This is analogous to a list of hash keys.
+
+Decrypt the entire root item in the passwords vault and print in json
+format.
+
+    knife decrypt passwords root -Fjson
 
 Decrypt the username and password for the item root in the vault passwords.
 
@@ -165,5 +170,12 @@ Decrypt the contents for the item user_pem in the vault certs.
     <td>Chef mode to run in</td>
     <td>solo</td>
     <td>"solo", "client"</td>
+  </tr>
+  <tr>
+    <td>-F FORMAT</td>
+    <td>--format FORMAT</td>
+    <td>Format for output</td>
+    <td>summary</td>
+    <td>"summary", "json", "yaml", "pp"</td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
 
 ### Encrypt
 
-    knife encrypt create [VAULT] [ITEM] [VALUES]
-    knife encrypt update [VAULT] [ITEM] [VALUES]
-    knife encrypt remove [VAULT] [ITEM] [VALUES]
-    knife encrypt delete [VAULT] [ITEM]
-    knife encrypt rotate keys [VAULT] [ITEM]
+    knife encrypt create VAULT ITEM VALUES
+    knife encrypt update VAULT ITEM VALUES
+    knife encrypt remove VAULT ITEM VALUES
+    knife encrypt delete VAULT ITEM
+    knife encrypt rotate keys VAULT ITEM
 
 <i>Global Options:</i>
 <table>
@@ -79,7 +79,7 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
 
 ### Decrypt
 
-    knife decrypt [VAULT] [ITEM] [VALUES]
+    knife decrypt VAULT ITEM [VALUES]
 
 <i>Global Options:</i>
 <table>
@@ -96,6 +96,13 @@ NOTE: chef-vault 1.0 knife commands are not supported!  Please use chef-vault 2.
     <td>Chef mode to run in</td>
     <td>solo</td>
     <td>"solo", "client"</td>
+  </tr>
+  <tr>
+    <td>-F FORMAT</td>
+    <td>--format FORMAT</td>
+    <td>Format for output</td>
+    <td>summary</td>
+    <td>"summary", "json", "yaml", "pp"</td>
   </tr>
 </table>
 
@@ -130,9 +137,9 @@ Do `chef-vault --help` for all available options
 
 ## License and Author:
 
-Author:: Kevin Moser (<kevin.moser@nordstrom.com>)  
-Copyright:: Copyright (c) 2013 Nordstrom, Inc.  
-License:: Apache License, Version 2.0  
+Author:: Kevin Moser (<kevin.moser@nordstrom.com>)
+Copyright:: Copyright (c) 2013 Nordstrom, Inc.
+License:: Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/lib/chef/knife/Decrypt.rb
+++ b/lib/chef/knife/Decrypt.rb
@@ -25,7 +25,7 @@ class Decrypt < Chef::Knife
     include ChefVault::Mixin::Helper
   end
 
-  banner "knife decrypt [VAULT] [ITEM] [VALUES] --mode MODE"
+  banner "knife decrypt VAULT ITEM [VALUES] --mode MODE"
 
   option :mode,
     :short => '-M MODE',

--- a/lib/chef/knife/encrypt_create.rb
+++ b/lib/chef/knife/encrypt_create.rb
@@ -25,7 +25,7 @@ class EncryptCreate < Chef::Knife
     include ChefVault::Mixin::Helper
   end
 
-  banner "knife encrypt create [VAULT] [ITEM] [VALUES] "\
+  banner "knife encrypt create VAULT ITEM VALUES "\
         "--mode MODE --search SEARCH --admins ADMINS --json FILE --file FILE"
 
   option :mode,
@@ -52,7 +52,7 @@ class EncryptCreate < Chef::Knife
     :long => '--file FILE',
     :description => 'File to be added to vault item as file-content'
 
-    def run
+  def run
     vault = @name_args[0]
     item = @name_args[1]
     values = @name_args[2]
@@ -73,7 +73,7 @@ class EncryptCreate < Chef::Knife
       rescue ChefVault::Exceptions::KeysNotFound,
              ChefVault::Exceptions::ItemNotFound
         vault_item = ChefVault::Item.new(vault, item)
-       
+
         merge_values(values, json_file).each do |key, value|
           vault_item[key] = value
         end
@@ -98,4 +98,4 @@ class EncryptCreate < Chef::Knife
     exit 1
   end
 end
-  
+

--- a/lib/chef/knife/encrypt_delete.rb
+++ b/lib/chef/knife/encrypt_delete.rb
@@ -25,7 +25,7 @@ class EncryptDelete < Chef::Knife
     include ChefVault::Mixin::Helper
   end
 
-  banner "knife encrypt delete [VAULT] [ITEM] --mode MODE"
+  banner "knife encrypt delete VAULT ITEM --mode MODE"
 
   option :mode,
     :short => '-M MODE',
@@ -45,8 +45,8 @@ class EncryptDelete < Chef::Knife
         rescue ChefVault::Exceptions::KeysNotFound,
                ChefVault::Exceptions::ItemNotFound
 
-               raise ChefVault::Exceptions::ItemNotFound,
-                     "#{vault}/#{item} not found."
+          raise ChefVault::Exceptions::ItemNotFound,
+                "#{vault}/#{item} not found."
         end
       end
     else
@@ -59,4 +59,4 @@ class EncryptDelete < Chef::Knife
     exit 1
   end
 end
-  
+

--- a/lib/chef/knife/encrypt_remove.rb
+++ b/lib/chef/knife/encrypt_remove.rb
@@ -25,7 +25,7 @@ class EncryptRemove < Chef::Knife
     include ChefVault::Mixin::Helper
   end
 
-  banner "knife encrypt remove [VAULT] [ITEM] [VALUES] "\
+  banner "knife encrypt remove VAULT ITEM VALUES "\
         "--mode MODE --search SEARCH --admins ADMINS"
 
   option :mode,
@@ -73,9 +73,9 @@ class EncryptRemove < Chef::Knife
           remove_items.each do |key|
             key.strip!
             vault_item.remove(key)
-          end 
+          end
         end
-        
+
         vault_item.clients(search, :delete) if search
         vault_item.admins(admins, :delete) if admins
 
@@ -97,4 +97,4 @@ class EncryptRemove < Chef::Knife
     exit 1
   end
 end
-  
+

--- a/lib/chef/knife/encrypt_rotate_keys.rb
+++ b/lib/chef/knife/encrypt_rotate_keys.rb
@@ -25,7 +25,7 @@ class EncryptRotateKeys < Chef::Knife
     include ChefVault::Mixin::Helper
   end
 
-  banner "knife encrypt rotate keys [VAULT] [ITEM] --mode MODE"
+  banner "knife encrypt rotate keys VAULT ITEM --mode MODE"
 
   option :mode,
     :short => '-M MODE',
@@ -59,4 +59,4 @@ class EncryptRotateKeys < Chef::Knife
     exit 1
   end
 end
-  
+

--- a/lib/chef/knife/encrypt_update.rb
+++ b/lib/chef/knife/encrypt_update.rb
@@ -25,7 +25,7 @@ class EncryptUpdate < Chef::Knife
     include ChefVault::Mixin::Helper
   end
 
-  banner "knife encrypt update [VAULT] [ITEM] [VALUES] "\
+  banner "knife encrypt update VAULT ITEM VALUES "\
         "--mode MODE --search SEARCH --admins ADMINS --json FILE --file FILE"
 
   option :mode,
@@ -69,7 +69,7 @@ class EncryptUpdate < Chef::Knife
 
         merge_values(values, json_file).each do |key, value|
           vault_item[key] = value
-        end 
+        end
 
         if file
           vault_item["file-name"] = File.basename(file)
@@ -97,4 +97,4 @@ class EncryptUpdate < Chef::Knife
     exit 1
   end
 end
-  
+


### PR DESCRIPTION
Fixes #50: Use standard chef/knife formatting for all knife decrypt output

Went through files and removed use of brackets where command-line arguments are mandatory.  Left brackets in where arguments are optional.

Minor formatting - whitespace removal, fixed an indent on a def.

Updated README.md and KNIFE_EXAMPLES.md to include formatting options.

If you guys want me to add the brackets back in, I can ammend these commits.  I just know when we started using chef-vault, there were rumblings from some of us about the use of brackets on mandatory arguments ;)
