### PR TITLE
Fixes #79: "Released" date of version "v2.2.0"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 ## Planned (Unreleased)
 
 ## Released
-## v2.2.0 / 2013-01-21
+## v2.2.0 / 2014-01-21
 * Validate data bag ID before saving
 * Add search_query to vault metadata
 * Refactor knife commands to be knife vault verb


### PR DESCRIPTION
Fixes #79: Corrected "Released" date of version "v2.2.0"

Existing "Released" date is showing as "## v2.2.0 / 2013-01-21" which is not correct. Corrected to "## v2.2.0 / 2014-01-21". Year should be 2014 not 2013!
