### PR TITLE
Rspec: Require 'expect' syntax

### DIFF
--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -39,4 +39,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler', '~> 1.3'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14'
+  s.add_development_dependency 'simplecov'
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,11 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
+  # disable should syntax
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.


### PR DESCRIPTION
This change diables the traditional `should` syntax in favor of
the new `expect` syntax. See this blog post for more details:
http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
