### PR TITLE
add recognition of 'name' in response

### DIFF
--- a/lib/chef-vault/chef_patch/api_client.rb
+++ b/lib/chef-vault/chef_patch/api_client.rb
@@ -25,7 +25,7 @@ class ChefVault
           response
         else
           client = Chef::ApiClient.new
-          client.name(response['clientname'])
+          client.name(response['clientname'] || response['name'])
 
           if response['certificate']
             der = OpenSSL::X509::Certificate.new response['certificate']


### PR DESCRIPTION
Some chef servers send a field with the key 'name' instead of the field 'clientname'  in their response. If the name of the client isn't correct the data will be stored the wrong way, so that the client won't be able to decrypt.