### PR TITLE
Feature - knife vault update - update item_keys only when no value is provided

### DIFF
--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -122,3 +122,19 @@ Given(/^I downgrade the vault item '(.+)\/(.+)' to v1 syntax/) do |vault, item|
   %w{admins clients search_query}.each { |k| data.key?("raw_data") ? data["raw_data"].delete(k) : data.delete(k) }
   IO.write(keysfile, JSON.generate(data))
 end
+
+Given(/^I can save the JSON object of the encrypted data bag for the vault item '(.+)\/(.+)'$/) do |vault, item|
+  command = "knife data bag show #{vault} #{item} -z -c knife.rb -F json"
+  run_simple(command)
+  output = last_command_started.stdout
+  @saved_encrypted_vault_item = JSON.parse(output)
+end
+
+Given(/^the data bag of the vault item '(.+)\/(.+)' has not been re-encrypted$/) do |vault, item|
+  command = "knife data bag show #{vault} #{item} -z -c knife.rb -F json"
+  run_simple(command)
+  output = last_command_started.stdout
+  encrypted_vault_item = JSON.parse(output)
+
+  expect(encrypted_vault_item).to eq(@saved_encrypted_vault_item)
+end

--- a/features/vault_update.feature
+++ b/features/vault_update.feature
@@ -11,7 +11,9 @@ Feature: knife vault update
       And 'alice' should be an admin for the vault item 'test/item'
       And I can decrypt the vault item 'test/item' as 'alice'
       But I can't decrypt the vault item 'test/item' as 'bob'
+      And I can save the JSON object of the encrypted data bag for the vault item 'test/item'
     When I add 'bob' as an admin for the vault item 'test/item'
     Then 'alice,bob' should be an admin for the vault item 'test/item'
       And I can decrypt the vault item 'test/item' as 'alice'
       And I can decrypt the vault item 'test/item' as 'bob'
+      And the data bag of the vault item 'test/item' has not been re-encrypted

--- a/features/vault_update.feature
+++ b/features/vault_update.feature
@@ -1,17 +1,17 @@
 Feature: knife vault update
 
   'knife vault update' is used to add clients, or administrators
-  and to re-run the search query
+  and to re-run the search query and update the vault's item values.
 
   Scenario: add admin to a vault
     Given a local mode chef repo with nodes 'one,two,three' with admins 'alice,bob'
-    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three' with 'alice' as admin
+    When I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three' with 'alice' as admin
     Then the vault item 'test/item' should be encrypted for 'one,two,three'
-    And 'one,two,three' should be a client for the vault item 'test/item'
-    And 'alice' should be an admin for the vault item 'test/item'
-    And I can decrypt the vault item 'test/item' as 'alice'
-    And I can't decrypt the vault item 'test/item' as 'bob'
-    And I add 'bob' as an admin for the vault item 'test/item'
+      And 'one,two,three' should be a client for the vault item 'test/item'
+      And 'alice' should be an admin for the vault item 'test/item'
+      And I can decrypt the vault item 'test/item' as 'alice'
+      But I can't decrypt the vault item 'test/item' as 'bob'
+    When I add 'bob' as an admin for the vault item 'test/item'
     Then 'alice,bob' should be an admin for the vault item 'test/item'
-    And I can decrypt the vault item 'test/item' as 'alice'
-    And I can decrypt the vault item 'test/item' as 'bob'
+      And I can decrypt the vault item 'test/item' as 'alice'
+      And I can decrypt the vault item 'test/item' as 'bob'

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -218,7 +218,7 @@ class ChefVault
       end
     end
 
-    def save_keys(item_id)
+    def save_keys(item_id = @raw_data["id"])
       # validate the format of the id before attempting to save
       validate_id!(item_id)
 


### PR DESCRIPTION
`knife vault update` subcommand does 2 things

* Can update the vault's item value(s)
* Can update the item keys list (Nodes, via `search-query`, or Admins)

Or both in the same command

```ruby
knife vault update VAULT ITEM [-S ] [-A]
```

However, it saves the whole `vault_item` objects ( `${item}` and `${item_keys}` data bag items) even if only clients or admins are provided  ( `${item_keys}`).

This PR goes along e87c70c and issue : https://github.com/chef/chef-vault/issues/193

It is needed when your source of truth is your VCS, and you update your Chef-server via files sync.
