### PR TITLE
Correct vault creation in solo mode

### DIFF
--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -61,7 +61,8 @@ class Chef
               "use 'knife vault remove' 'knife vault update' "\
               "or 'knife vault edit' to make changes."
           rescue ChefVault::Exceptions::KeysNotFound,
-                 ChefVault::Exceptions::ItemNotFound
+                 ChefVault::Exceptions::ItemNotFound,
+                 Chef::Exceptions::InvalidDataBagItemID
             vault_item = ChefVault::Item.new(vault, item)
             if values || json_file || file
               merge_values(values, json_file).each do |key, value|


### PR DESCRIPTION
Recent patch in chef (released in 12.8.1) raises a new exception when
checking an non-existent item in solo mode.
We need to catch this exception to allow vault item creation.

Kinda fix #203