### PR TITLE
Add support for clients

### DIFF
--- a/KNIFE_EXAMPLES.md
+++ b/KNIFE_EXAMPLES.md
@@ -13,13 +13,25 @@ These are the commands that are used to take data in JSON format and encrypt tha
 ## vault commands
 
 ### create
+Create a vault called passwords and put an item called root in it with the given values for username and password encrypted for clients role:webserver, client1 & client2 and admins admin1 & admin2
+
+    knife vault create passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -C "client1,client2" -A "admin1,admin2"
+
 Create a vault called passwords and put an item called root in it with the given values for username and password encrypted for clients role:webserver and admins admin1 & admin2
 
     knife vault create passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -A "admin1,admin2"
 
+Create a vault called passwords and put an item called root in it with the given values for username and password encrypted for clients role:webserver, client1 & client2
+
+    knife vault create passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -C "client1,client2"
+
 Create a vault called passwords and put an item called root in it with the given values for username and password encrypted for clients role:webserver
 
     knife vault create passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver"
+
+Create a vault called passwords and put an item called root in it with the given values for username and password encrypted for clients client1 & client2
+
+    knife vault create passwords root '{"username": "root", "password": "mypassword"}' -C "client1,client2"
 
 Create a vault called passwords and put an item called root in it with the given values for username and password encrypted for admins admin1 & admin2
 
@@ -37,29 +49,49 @@ Update the values in username and password in the vault passwords and item root.
 
     knife vault update passwords root '{"username": "root", "password": "mypassword"}'
 
-Update the values in username and password in the vault passwords and item root and add admin1 & admin2 to the encrypted admins.  Will overwrite existing values if values already exist!
+Update the values in username and password in the vault passwords and item root and add role:webserver, client1 & client2 to the encrypted clients and admin1 & admin2 to the encrypted admins.  Will overwrite existing values if values already exist!
 
-    knife vault update passwords root '{"username": "root", "password": "mypassword"}' -A "admin1,admin2"
-
-Update the values in username and password in the vault passwords and item root and add role:webserver to the encrypted clients.  Will overwrite existing values if values already exist!
-
-    knife vault update passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver"
+    knife vault update passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -C "client1,client2" -A "admin1,admin2"
 
 Update the values in username and password in the vault passwords and item root and add role:webserver to the encrypted clients and admin1 & admin2 to the encrypted admins.  Will overwrite existing values if values already exist!
 
     knife vault update passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -A "admin1,admin2"
 
-Add admin1 & admin2 to encrypted admins for the vault passwords and item root.
+Update the values in username and password in the vault passwords and item root and add role:webserver to the encrypted clients.  Will overwrite existing values if values already exist!
 
-    knife vault update passwords root -A "admin1,admin2"
+    knife vault update passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver"
+
+Update the values in username and password in the vault passwords and item root and add client1 & client2 to the encrypted clients.  Will overwrite existing values if values already exist!
+
+    knife vault update passwords root '{"username": "root", "password": "mypassword"}' -C "client1,client2"
+
+Update the values in username and password in the vault passwords and item root and add admin1 & admin2 to the encrypted admins.  Will overwrite existing values if values already exist!
+
+    knife vault update passwords root '{"username": "root", "password": "mypassword"}' -A "admin1,admin2"
 
 Add role:webserver to encrypted clients for the vault passwords and item root.
 
     knife vault update passwords root -S "role:webserver"
 
+Add client1 & client2 to encrypted clients for the vault passwords and item root.
+
+    knife vault update passwords root -C "client1,client2"
+
+Add admin1 & admin2 to encrypted admins for the vault passwords and item root.
+
+    knife vault update passwords root -A "admin1,admin2"
+
+Add admin1 & admin2 to encrypted admins and role:webserver, client1 & client2 to encrypted clients for the vault passwords and item root.
+
+    knife vault update passwords root -S "role:webserver" -C "client1,client2" -A "admin1,admin2"
+
 Add admin1 & admin2 to encrypted admins and role:webserver to encrypted clients for the vault passwords and item root.
 
     knife vault update passwords root -S "role:webserver" -A "admin1,admin2"
+
+Add admin1 & admin2 to encrypted admins and client1 & client2 to encrypted clients for the vault passwords and item root.
+
+    knife vault update passwords root -C "client1,client2" -A "admin1,admin2"
 
 Note: A JSON file can be used in place of specifying the values on the command line, see global options below for details
 
@@ -69,29 +101,49 @@ Remove the values in username and password from the vault passwords and item roo
 
     knife vault remove passwords root '{"username": "root", "password": "mypassword"}'
 
-Remove the values in username and password from the vault passwords and item root and remove admin1 & admin2 from the encrypted admins.
+Remove the values in username and password from the vault passwords and item root and remove role:webserver, client1 & client2 from the encrypted clients and admin1 & admin2 from the encrypted admins.
 
-    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -A "admin1,admin2"
-
-Remove the values in username and password from the vault passwords and item root and remove role:webserver from the encrypted clients.
-
-    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver"
+    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -C "client1,client2" -A "admin1,admin2"
 
 Remove the values in username and password from the vault passwords and item root and remove role:webserver from the encrypted clients and admin1 & admin2 from the encrypted admins.
 
     knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver" -A "admin1,admin2"
 
-Remove admin1 & admin2 from encrypted admins for the vault passwords and item root.
+Remove the values in username and password from the vault passwords and item root and remove client1 & client2 from the encrypted clients and admin1 & admin2 from the encrypted admins.
 
-    knife vault remove passwords root -A "admin1,admin2"
+    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -C "client1,client2" -A "admin1,admin2"
+
+Remove the values in username and password from the vault passwords and item root and remove role:webserver from the encrypted clients.
+
+    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -S "role:webserver"
+
+Remove the values in username and password from the vault passwords and item root and remove client1 & client2 from the encrypted clients.
+
+    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -C "client1,client2"
+
+Remove the values in username and password from the vault passwords and item root and remove admin1 & admin2 from the encrypted admins.
+
+    knife vault remove passwords root '{"username": "root", "password": "mypassword"}' -A "admin1,admin2"
+
+Remove admin1 & admin2 from encrypted admins and role:webserver, client1 & client2 from encrypted clients for the vault passwords and item root.
+
+    knife vault remove passwords root -S "role:webserver" -C "client1,client2" -A "admin1,admin2"
+
+Remove admin1 & admin2 from encrypted admins and role:webserver from encrypted clients for the vault passwords and item root.
+
+    knife vault remove passwords root -S "role:webserver" -A "admin1,admin2"
 
 Remove role:webserver from encrypted clients for the vault passwords and item root.
 
     knife vault remove passwords root -S "role:webserver"
 
-Remove admin1 & admin2 from encrypted admins and role:webserver from encrypted clients for the vault passwords and item root.
+Remove client1 & client2 from encrypted clients for the vault passwords and item root.
 
-    knife vault remove passwords root -S "role:webserver" -A "admin1,admin2"
+    knife vault remove passwords root -C "client1,client2"
+
+Remove admin1 & admin2 from encrypted admins for the vault passwords and item root.
+
+    knife vault remove passwords root -A "admin1,admin2"
 
 ### delete
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Short | Long | Description | Default | Valid Values | Sub-Commands
 ------|------|-------------|---------|--------------|-------------
 -M MODE | --mode MODE | Chef mode to run in. Can be set in knife.rb | solo | solo, client | all
 -S SEARCH | --search SEARCH | Chef Server SOLR Search Of Nodes | | | create, remove , update
+-C CLIENTS | --clients CLIENTS | Chef clients to be added as clients, can be comma list | | | create, remove , update
 -A ADMINS | --admins ADMINS | Chef clients or users to be vault admins, can be comma list | | | create, remove, update
 -J FILE | --json FILE | JSON file to be used for values, will be merged with VALUES if VALUES is passed | | | create, update
 | --file FILE | File that chef-vault should encrypt.  It adds "file-content" & "file-name" keys to the vault item | | | create, update

--- a/lib/chef/knife/vault_clients.rb
+++ b/lib/chef/knife/vault_clients.rb
@@ -1,0 +1,26 @@
+# Description: Chef-Vault VaultClients module
+# Copyright 2014-15, Nordstrom, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Chef
+  class Knife
+    module VaultClients
+      private
+
+      def clients
+        config[:clients].split(",") if config[:clients]
+      end
+    end
+  end
+end

--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -15,12 +15,14 @@
 
 require "chef/knife/vault_base"
 require "chef/knife/vault_admins"
+require "chef/knife/vault_clients"
 
 class Chef
   class Knife
     class VaultCreate < Knife
       include Chef::Knife::VaultBase
       include Chef::Knife::VaultAdmins
+      include Chef::Knife::VaultClients
 
       banner "knife vault create VAULT ITEM VALUES (options)"
 
@@ -28,6 +30,11 @@ class Chef
         :short => "-S SEARCH",
         :long => "--search SEARCH",
         :description => "Chef SOLR search for clients"
+
+      option :clients,
+        :short => "-C CLIENTS",
+        :long => "--clients CLIENTS",
+        :description => "Chef clients to be added as clients"
 
       option :admins,
         :short => "-A ADMINS",
@@ -53,7 +60,7 @@ class Chef
 
         set_mode(config[:vault_mode])
 
-        if vault && item && (search || admins)
+        if vault && item && (search || clients || admins)
           begin
             vault_item = ChefVault::Item.load(vault, item)
             raise ChefVault::Exceptions::ItemAlreadyExists,
@@ -82,6 +89,7 @@ class Chef
 
             vault_item.search(search) if search
             vault_item.clients(search) if search
+            vault_item.clients(clients) if clients
             vault_item.admins(admins) if admins
 
             vault_item.save

--- a/lib/chef/knife/vault_remove.rb
+++ b/lib/chef/knife/vault_remove.rb
@@ -14,11 +14,13 @@
 # limitations under the License.
 
 require "chef/knife/vault_base"
+require "chef/knife/vault_clients"
 
 class Chef
   class Knife
     class VaultRemove < Knife
       include Chef::Knife::VaultBase
+      include Chef::Knife::VaultClients
 
       banner "knife vault remove VAULT ITEM VALUES (options)"
 
@@ -26,6 +28,11 @@ class Chef
         :short => "-S SEARCH",
         :long => "--search SEARCH",
         :description => "Chef SOLR search for clients"
+
+      option :clients,
+        :short => "-C CLIENTS",
+        :long => "--clients CLIENTS",
+        :description => "Chef clients to be added as clients"
 
       option :admins,
         :short => "-A ADMINS",
@@ -47,7 +54,7 @@ class Chef
 
         set_mode(config[:vault_mode])
 
-        if vault && item && ((values || json_file) || (search || admins))
+        if vault && item && ((values || json_file) || (search || clients || admins))
           begin
             vault_item = ChefVault::Item.load(vault, item)
             remove_items = []
@@ -69,6 +76,7 @@ class Chef
             end
 
             vault_item.clients(search, :delete) if search
+            vault_item.clients(clients, :delete) if clients
             vault_item.admins(admins, :delete) if admins
 
             vault_item.rotate_keys!(clean_unknown_clients)


### PR DESCRIPTION
Before finishing up this PR I would like some feedback about the feasibility of getting this functionality merged in `chef-vault`?

The reason we have a need for this is because we would like the [Terraform `chef` provisioner](https://www.terraform.io/docs/provisioners/chef.html) to be able to add single clients in the same way as `knife bootstrap` currently does. `knife bootstrap` does this by directly calling/using the `chef-vault` package, but that approach is not possible for the `chef` provisioner.

So [currently](https://github.com/hashicorp/terraform/blob/master/builtin/provisioners/chef/resource_provisioner.go#L559-L591) we add `clients` as `admins`, but of course this has all kinds of nasty side effects and is now how `chef-vault` should be used so people are [not happy](https://github.com/hashicorp/terraform/issues/9137) with that approach. 

Besides this very specific reason, I would imagine that this is adds value by extending the number use cases in which `knife vault` can be used.

I really hope this is something that can be merged as it would make the Terraform `chef` provisioner able to handle `chef-vaults` correctly and with that have better Chef support/integration.

_EDIT: I know this branch is outdated because I based it of v2.9.0 instead of master. I will of course rebase this if/when we can move forward with this PR!_