### PR TITLE
Change the chef dependency to development only

### DIFF
--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -45,6 +45,6 @@ Gem::Specification.new do |s|
     # /orgs/org/users/user/keys endpoint was added.
     s.add_development_dependency "chef", "12.8.1"
   else # Test most current version of Chef on 2.2.2
-    s.add_dependency :chef, "~> 12"
+    s.add_development_dependency :chef
   end
 end

--- a/lib/chef-vault/version.rb
+++ b/lib/chef-vault/version.rb
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 class ChefVault
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
   MAJOR, MINOR, TINY = VERSION.split(".")
 end


### PR DESCRIPTION
The rubygem old ones are angry that our depepdencies are expressed
correctly, so stop doing so.