### PR TITLE
Avoid re-encrypting key for all existing clients

### DIFF
--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -172,6 +172,9 @@ class ChefVault
     def rotate_keys!(clean_unknown_clients = false)
       @secret = generate_secret
 
+      # clean existing encrypted data for clients/admins
+      keys.clear_encrypted
+
       unless get_clients.empty?
         # a bit of a misnomer; this doesn't remove unknown
         # admins, just clients which are nodes

--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -64,14 +64,21 @@ class ChefVault
         raise ChefVault::Exceptions::V1Format,
               "cannot manage a v1 vault.  See UPGRADE.md for help"
       end
-      @cache[chef_key.name] = ChefVault::ItemKeys.encode_key(chef_key.key, data_bag_shared_secret)
+      @cache[chef_key.name] = self[chef_key.name] || ChefVault::ItemKeys.encode_key(chef_key.key, data_bag_shared_secret)
       @raw_data[type] << chef_key.name unless @raw_data[type].include?(chef_key.name)
       @raw_data[type]
+    end
+
+    def clear_encrypted
+      @cache.clear
+      self["clients"].each { |client| @raw_data.delete(client) }
+      self["admins"].each { |admin| @raw_data.delete(admin) }
     end
 
     def delete(chef_key)
       @cache[chef_key.name] = false
       raw_data[chef_key.type].delete(chef_key.name)
+      raw_data.delete(chef_key.name)
     end
 
     def mode(mode = nil)

--- a/spec/chef-vault/item_keys_spec.rb
+++ b/spec/chef-vault/item_keys_spec.rb
@@ -36,12 +36,27 @@ RSpec.describe ChefVault::ItemKeys do
             keys.delete(chef_key)
           end
 
-          it "stores the encoded key in the data bag item under the actor's name and the name in the raw data" do
-            expect(described_class).to receive(:encode_key).with(public_key_string, shared_secret).and_return("encrypted_result")
-            keys.add(chef_key, shared_secret)
-            expect(keys[name]).to eq("encrypted_result")
-            expect(keys[type].include?(name)).to eq(true)
-            expect(keys.include?(name)).to eq(true)
+          context "when key is already there" do
+            it "keeps the encoded key in the data bag item under the actor's name and the name in the raw data" do
+              expect(described_class).not_to receive(:encode_key).with(public_key_string, shared_secret)
+              keys.add(chef_key, shared_secret)
+              expect(keys[name]).not_to be_empty
+              expect(keys[type].include?(name)).to eq(true)
+              expect(keys.include?(name)).to eq(true)
+            end
+          end
+
+          context "when keys not already there" do
+            before do
+              keys.delete(chef_key)
+            end
+            it "stores the encoded key in the data bag item under the actor's name and the name in the raw data" do
+              expect(described_class).to receive(:encode_key).with(public_key_string, shared_secret).and_return("encrypted_result")
+              keys.add(chef_key, shared_secret)
+              expect(keys[name]).to eq("encrypted_result")
+              expect(keys[type].include?(name)).to eq(true)
+              expect(keys.include?(name)).to eq(true)
+            end
           end
         end
 

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe ChefVault::Item do
 
   before do
     item["foo"] = "bar"
+    http_response = double("http_response")
+    allow(http_response).to receive(:code).and_return("404")
+    non_existing = Net::HTTPServerException.new("http error message", http_response)
+
+    allow(Chef::DataBagItem).to receive(:load).with(anything, /_key_/).and_raise(non_existing)
   end
 
   describe "vault probe predicates" do


### PR DESCRIPTION
Before this patch, symetrical key was encrypted for all clients on refresh.
With this patch, we only encrypt symetrical key for new clients and re-use previously encrypted key.

This patch requires to improve "vault remove" scenario to clear encrypted data before re-encrypting.

Change-Id: I0abccb32d45deb6ae51a1afdaff54c1e7c994e29