### PR TITLE
Make sure sparse mode is used on secrets where it is explicit

### DIFF
--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -39,7 +39,7 @@ class ChefVault
       ckey = @cache[key]
       return ckey unless ckey.nil?
       # check if the key is saved in sparse mode
-      skey = sparse_key(sparse_id(key))
+      skey = sparse_key(sparse_id(key)) if sparse?
       if skey
         skey[key]
       else
@@ -212,6 +212,10 @@ class ChefVault
     end
 
     # @private
+
+    def sparse?
+      @raw_data["mode"] == "sparse"
+    end
 
     def sparse_id(key, item_id = @raw_data["id"])
       "#{item_id.chomp("_keys")}_key_#{key}"


### PR DESCRIPTION
Sparse mode is marked in xxx_keys item with:

> mode: "sparse"

but when decrypting secrets, each node is trying to read the sparse format first
(xxx_key_[node]) and then fallback to normal xxx_keys.
This adds a performance penalty both on reading secrets and during refresh.

With this patch, sparse format is checked only when secret is marked as sparse.

This makes refresh a fast no-op (it was already a no-op with
https://github.com/chef/chef-vault/pull/269 now it is faster) since the only
cost is now searching nodes matching search_query.