### PR TITLE
Reduce the search response limit from 100k to 10k

### DIFF
--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -103,7 +103,7 @@ class ChefVault
         results_returned = false
         results = []
         query = Chef::Search::Query.new
-        query.search(:node, statement, filter_result: { name: ["name"] }, rows: 100000) do |node|
+        query.search(:node, statement, filter_result: { name: ["name"] }, rows: 10000) do |node|
           results_returned = true
           results << node["name"]
         end


### PR DESCRIPTION
The default index.max_result_window for Elasticsearch is 10k. This leads to errors like:

2017-05-03_19:36:41.82788 Caused by: QueryPhaseExecutionException[Result window is too large, from + size must be less than or equal to: [10000] but was [100000]. See the scroll api for a more efficient way to request large data sets. This limit can be set by changing the [index.max_result_window] index level parameter.]

Signed-off-by: Bryan McLellan <btm@loftninjas.org>