### PR TITLE
Avoid sparse key read for non sparse secrets

### DIFF
--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -53,7 +53,7 @@ class ChefVault
       ckey = @cache[key]
       return (ckey ? true : false) unless ckey.nil?
       # check if the key is saved in sparse mode
-      return true unless sparse_key(sparse_id(key)).nil?
+      return true if sparse? && sparse_key(sparse_id(key))
       # fallback to non-sparse mode if sparse key is not found
       @raw_data.keys.include?(key)
     end


### PR DESCRIPTION
Before this patch, every call to ChefVault::Item.load used to call the
chef server for sparse key twice:
- once to load keys
- once to decrypt symetrical key

This has a huge cost on secret read for nodes whose latency to the chef
server is high (we have example with ~300ms ping time).

This patch make sure we don't try to read sparse key when the secret is
marked as non sparse.

Signed-off-by: Grégoire Seux <g.seux@criteo.com>