### PR TITLE
Fix fatal error during create

### DIFF
--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -87,7 +87,7 @@ class Chef
                 vault_item["file-content"] = File.open(file) { |f| f.read() }
               end
             else
-              vault_json = edit_data({})
+              vault_json = edit_hash({})
               vault_json.each do |key, value|
                 vault_item[key] = value
               end


### PR DESCRIPTION
Similar to GH-274, replaces the usage of edit_data with edit_hash to fix
errors in chef 13 and warnings in chef 12.
