### PR TITLE
Allow to force reencryption of keys during refresh

### DIFF
--- a/features/clean_on_refresh.feature
+++ b/features/clean_on_refresh.feature
@@ -9,7 +9,7 @@ Feature: clean unknown clients on vault refresh
     Given a local mode chef repo with nodes 'one,two,three'
     And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
     Then the vault item 'test/item' should be encrypted for 'one,two,three'
-    And I delete client 'one' from the Chef server
+    And I delete node 'one' from the Chef server
     And I refresh the vault item 'test/item'
     And the vault item 'test/item' should be encrypted for 'one,two,three'
     And 'one,two,three' should be a client for the vault item 'test/item'

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -47,6 +47,9 @@ class ChefVault
     # revisit this as part of the 3.x rewrite
     def_delegator :@raw_data, :keys, :raw_keys
 
+    # allow to control whether keys are reencrypted or cached
+    def_delegator :keys, :skip_reencryption=
+
     # constructs a new ChefVault::Item
     # @param vault [String] the name of the data bag that contains the vault
     # @param name [String] the name of the item in the vault
@@ -441,6 +444,7 @@ class ChefVault
     def handle_client_action(api_client, action)
       case action
       when :add
+        # TODO: next line seems to create a client from the api_client (which seems to be identical)
         client = load_actor(api_client.name, "clients")
         add_client(client)
       when :delete

--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -21,6 +21,10 @@ class ChefVault
 
     include ChefVault::Mixins
 
+    # @!attribute [rw] skip_reencryption
+    #   @return [TrueClass,FalseClass] whether symetrical key is reencrypted all the time or re-used from previous computations
+    attr_accessor :skip_reencryption
+
     def initialize(vault, name)
       super() # parentheses required to strip off parameters
       @data_bag = vault
@@ -64,7 +68,8 @@ class ChefVault
         raise ChefVault::Exceptions::V1Format,
               "cannot manage a v1 vault.  See UPGRADE.md for help"
       end
-      @cache[chef_key.name] = self[chef_key.name] || ChefVault::ItemKeys.encode_key(chef_key.key, data_bag_shared_secret)
+      @cache[chef_key.name] = skip_reencryption ? self[chef_key.name] : nil
+      @cache[chef_key.name] ||= ChefVault::ItemKeys.encode_key(chef_key.key, data_bag_shared_secret)
       @raw_data[type] << chef_key.name unless @raw_data[type].include?(chef_key.name)
       @raw_data[type]
     end

--- a/lib/chef/knife/vault_refresh.rb
+++ b/lib/chef/knife/vault_refresh.rb
@@ -26,16 +26,22 @@ class Chef
         :long => "--clean-unknown-clients",
         :description => "Remove unknown clients during refresh"
 
+      option :skip_reencryption,
+        :long => "--skip-reencryption",
+        :description => "Skip reencrypt symetrical key for existing clients/admins."
+
       def run
         vault = @name_args[0]
         item = @name_args[1]
         clean = config[:clean_unknown_clients]
+        skip_reencryption = config[:skip_reencryption]
 
         set_mode(config[:vault_mode])
 
         if vault && item
           begin
             vault_item = ChefVault::Item.load(vault, item)
+            vault_item.skip_reencryption = skip_reencryption
             vault_item.refresh(clean)
           rescue ChefVault::Exceptions::KeysNotFound,
                  ChefVault::Exceptions::ItemNotFound

--- a/spec/chef-vault/item_keys_spec.rb
+++ b/spec/chef-vault/item_keys_spec.rb
@@ -37,12 +37,25 @@ RSpec.describe ChefVault::ItemKeys do
           end
 
           context "when key is already there" do
-            it "keeps the encoded key in the data bag item under the actor's name and the name in the raw data" do
-              expect(described_class).not_to receive(:encode_key).with(public_key_string, shared_secret)
-              keys.add(chef_key, shared_secret)
-              expect(keys[name]).not_to be_empty
-              expect(keys[type].include?(name)).to eq(true)
-              expect(keys.include?(name)).to eq(true)
+            context "when skip_reencryption is not specified (default to false)" do
+              it "encodes key in the data bag item under the actor's name and the name in the raw data" do
+                expect(described_class).to receive(:encode_key).with(public_key_string, shared_secret).and_return("encrypted_result")
+                keys.add(chef_key, shared_secret)
+                expect(keys[name]).to eq("encrypted_result")
+                expect(keys[type].include?(name)).to eq(true)
+                expect(keys.include?(name)).to eq(true)
+              end
+            end
+
+            context "when skip_reencryption is true" do
+              it "keeps the encoded key in the data bag item under the actor's name and the name in the raw data" do
+                expect(described_class).not_to receive(:encode_key).with(public_key_string, shared_secret)
+                keys.skip_reencryption = true
+                keys.add(chef_key, shared_secret)
+                expect(keys[name]).not_to be_empty
+                expect(keys[type].include?(name)).to eq(true)
+                expect(keys.include?(name)).to eq(true)
+              end
             end
           end
 


### PR DESCRIPTION
During a refresh operation, speed optimization lead to avoid
re-encrypting symetrical key for each existing clients.

This lead to issues when clients change their chef key.

This patch adds an option --skip-reencryption to workaround that for
users having such behavior.

Fix #286

Change-Id: I0ffa71934d29198fa71aa6e1a9630ad302e21f6a
Signed-off-by: Grégoire Seux <g.seux@criteo.com>