### PR TITLE
Only include necessary files when making a gem

### DIFF
--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.description      = s.summary
   s.homepage         = "https://github.com/chef/chef-vault"
   s.license          = "Apache License, v2.0"
-  s.files            = `git ls-files`.split("\n")
+  s.files            = `git ls-files`.split("\n").select { |f| f =~ %r{^(?:LiCENSE|bin/|lib/)}i }
   s.require_paths    = ["lib"]
   s.bindir           = "bin"
   s.executables      = %w{ chef-vault }


### PR DESCRIPTION
I don't know of any reason why specs and BDD features would be needed in a runtime setting, let alone a lot of the markdown documentation. Clearly the license should always remain with the code, but that's about it.

Removing all of those brought the file size of the `chef-vault-*.gem` file down from 52KB to 21KB with no functional changes at runtime.