### PR TITLE
Correct error message when missing public key

### DIFF
--- a/features/vault_create.feature
+++ b/features/vault_create.feature
@@ -17,8 +17,8 @@ Feature: knife vault create
     And I delete clients 'two,three' from the Chef server
     And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'two,three'
     Then the vault item 'test/item' should not be encrypted for 'one,two,three'
-    And the output should contain "node 'two' has no private key; skipping"
-    And the output should contain "node 'three' has no private key; skipping"
+    And the output should contain "node 'two' has no 'default' public key; skipping"
+    And the output should contain "node 'three' has no 'default' public key; skipping"
     And 'two,three' should not be a client for the vault item 'test/item'
 
   Scenario: create vault with mix of known and unknown clients
@@ -26,7 +26,7 @@ Feature: knife vault create
     And I delete client 'three' from the Chef server
     And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three'
     Then the vault item 'test/item' should be encrypted for 'one,two'
-    And the output should contain "node 'three' has no private key; skipping"
+    And the output should contain "node 'three' has no 'default' public key; skipping"
     And 'one,two' should be a client for the vault item 'test/item'
     And 'three' should not be a client for the vault item 'test/item'
 

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -93,7 +93,7 @@ class ChefVault
             client = load_actor(name, "clients")
             handle_client_action(client, action)
           rescue ChefVault::Exceptions::ClientNotFound
-            ChefVault::Log.warn "node '#{name}' has no private key; skipping"
+            ChefVault::Log.warn "node '#{name}' has no 'default' public key; skipping"
           end
         end
       end

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe ChefVault::Item do
 
       it "should emit a warning if search returns a node without a public key" do
         # it should however emit a warning that you have a borked node
-        expect(ChefVault::Log).to receive(:warn).with(/node 'bar' has no private key; skipping/)
+        expect(ChefVault::Log).to receive(:warn).with(/node 'bar' has no 'default' public key; skipping/)
         item.clients("*:*")
       end
     end


### PR DESCRIPTION
Wording was misleading since we raise the error when the public key is
missing.

Fix #295