### PR TITLE
Fix undefined method unpack for nil class error

### DIFF
--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -156,7 +156,7 @@ class ChefVault
     end
 
     def secret
-      if @keys.include?(@node_name)
+      if @keys.include?(@node_name) && !@keys[@node_name].nil?
         private_key = OpenSSL::PKey::RSA.new(File.open(@client_key_path).read())
         begin
           private_key.private_decrypt(Base64.decode64(@keys[@node_name]))


### PR DESCRIPTION
Sometimes, when the host has been re-registered, but `knife vault refresh` has not yet been launched, the `@raw_data` may contain a hash item with a value of `nil`:
{ ..., "name.of.the.host" => nil, ... }
In this case `@keys.include?(@node_name)` in `secret` method returns `true`, but `Base64.decode64(@keys[@node_name])` call leads to crash with "undefined method `unpack' for nil:NilClass" error.

Signed-off-by: Dmytro Shapovalov <shad@shad.in.ua>