### PR TITLE
Fix FrozenError when calling 'knife vault remove'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v3.3.1](https://github.com/chef/chef-vault/tree/v3.3.1) (2018-07-10)
+[Full Changelog](https://github.com/chef/chef-vault/compare/v3.3.0...v3.3.1)
+
+**Closed issues:**
+
+- Fix FrozenError when using 'knife vault remove'
+
 ## [v3.3.0](https://github.com/chef/chef-vault/tree/v3.3.0) (2017-07-28)
 [Full Changelog](https://github.com/chef/chef-vault/compare/v3.2.0...v3.3.0)
 

--- a/lib/chef/knife/vault_remove.rb
+++ b/lib/chef/knife/vault_remove.rb
@@ -71,8 +71,7 @@ class Chef
 
               remove_items.each do |key|
                 key = key.dup
-                key.strip!
-                vault_item.remove(key)
+                vault_item.remove(key.strip)
               end
             end
 

--- a/lib/chef/knife/vault_remove.rb
+++ b/lib/chef/knife/vault_remove.rb
@@ -70,6 +70,7 @@ class Chef
               end
 
               remove_items.each do |key|
+                key = key.dup
                 key.strip!
                 vault_item.remove(key)
               end


### PR DESCRIPTION
Environment:
```
$ chef -v
Chef Development Kit Version: 3.1.0
chef-client version: 14.2.0
delivery version: master (6862f27aba89109a9630f0b6c6798efec56b4efe)
berks version: 7.0.4
kitchen version: 1.22.0
inspec version: 2.1.72

$ chef gem list --local chef-vault

*** LOCAL GEMS ***

chef-vault (3.3.0)
```

Before patch:
```
$ knife vault show test-vault test-creds --format json
{
  "id": "test-creds",
  "_default": {
    "username": "kitchen_user",
    "password": "kitchen_password"
  },
  "staging": {
    "username": "staging_user",
    "password": "staging_password"
  },
  "production": {
    "username": "production_user",
    "password": "production_password"
  }
}
 
$ knife vault remove test-vault test-creds '{"staging": {"username": "staging_user", "password": "staging_password"}}' -VV
Traceback (most recent call last):
	11: from /opt/chefdk/bin/knife:272:in `<main>'
	10: from /opt/chefdk/bin/knife:272:in `load'
	 9: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/bin/knife:25:in `<top (required)>'
	 8: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/application/knife.rb:160:in `run'
	 7: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/knife.rb:220:in `run'
	 6: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/knife.rb:441:in `run_with_pretty_exceptions'
	 5: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/local_mode.rb:44:in `with_server_connectivity'
	 4: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-14.2.0/lib/chef/knife.rb:442:in `block in run_with_pretty_exceptions'
	 3: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-vault-3.3.0/lib/chef/knife/vault_remove.rb:72:in `run'
	 2: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-vault-3.3.0/lib/chef/knife/vault_remove.rb:72:in `each'
	 1: from /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-vault-3.3.0/lib/chef/knife/vault_remove.rb:73:in `block in run'
/opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/chef-vault-3.3.0/lib/chef/knife/vault_remove.rb:73:in `strip!': can't modify frozen String (FrozenError)

$ knife vault show test-vault test-creds --format json
{
  "id": "test-creds",
  "_default": {
    "username": "kitchen_user",
    "password": "kitchen_password"
  },
  "staging": {
    "username": "staging_user",
    "password": "staging_password"
  },
  "production": {
    "username": "production_user",
    "password": "production_password"
  }
}
```

After patch:
```
$ knife vault show test-vault test-creds --format json
{
  "id": "test-creds",
  "_default": {
    "username": "kitchen_user",
    "password": "kitchen_password"
  },
  "staging": {
    "username": "staging_user",
    "password": "staging_password"
  },
  "production": {
    "username": "production_user",
    "password": "production_password"
  }
}

$ knife vault remove test-vault test-creds '{"staging": {"username": "staging_user", "password": "staging_password"}}'

$ knife vault show test-vault test-creds --format json
{
  "id": "test-creds",
  "_default": {
    "username": "kitchen_user",
    "password": "kitchen_password"
  },
  "production": {
    "username": "production_user",
    "password": "production_password"
  }
}
```