### PR TITLE
update style to track an updated chefstyle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - "spec/data/**/*"
     - "vendor/**/*"
     - "pkg/**/*"
     - "tmp/**/*"
+# Disabled until the gem moves to supporting only Ruby 2.3+
+Layout/IndentHeredoc:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ branches:
   only:
   - master
 rvm:
-- 2.2.5
-- 2.3.1
-- 2.4.1
+- 2.2.10
+- 2.3.7
+- 2.4.4
+- 2.5.1
 install: bundle install --without changelog
 before_install: gem install bundler
 env: TRAVIS_BUILD=true

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,8 +7,8 @@ require "aruba/cucumber"
 # Travis runs tests in a limited environment which takes a long time to invoke
 # the knife command.  Up the timeout when we're in a travis build based on the
 # environment variable set in .travis.yml
-#if ENV['TRAVIS_BUILD']
+# if ENV['TRAVIS_BUILD']
 Before do
   @aruba_timeout_seconds = 15
 end
-#end
+# end

--- a/lib/chef-vault/chef_api.rb
+++ b/lib/chef-vault/chef_api.rb
@@ -20,19 +20,19 @@ class ChefVault
   class ChefApi
 
     def rest_v0
-      @rest_v0 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_root], { :api_version => "0" })
+      @rest_v0 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_root], { api_version: "0" })
     end
 
     def rest_v1
-      @rest_v1 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_root], { :api_version => "1" })
+      @rest_v1 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_root], { api_version: "1" })
     end
 
     def org_scoped_rest_v0
-      @org_scoped_rest_v0 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url], { :api_version => "0" })
+      @org_scoped_rest_v0 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url], { api_version: "0" })
     end
 
     def org_scoped_rest_v1
-      @org_scoped_rest_v1 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url], { :api_version => "1" })
+      @org_scoped_rest_v1 ||= Chef::ServerAPI.new(Chef::Config[:chef_server_url], { api_version: "1" })
     end
 
   end

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -66,8 +66,8 @@ class ChefVault
       @secret = generate_secret
       @encrypted = false
       opts = {
-        :node_name => Chef::Config[:node_name],
-        :client_key_path => Chef::Config[:client_key],
+        node_name: Chef::Config[:node_name],
+        client_key_path: Chef::Config[:client_key],
       }.merge(opts)
       @node_name = opts[:node_name]
       @client_key_path = opts[:client_key_path]

--- a/lib/chef-vault/version.rb
+++ b/lib/chef-vault/version.rb
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 class ChefVault
-  VERSION = "3.4.0"
+  VERSION = "3.4.0".freeze
   MAJOR, MINOR, TINY = VERSION.split(".")
 end

--- a/lib/chef/knife/vault_base.rb
+++ b/lib/chef/knife/vault_base.rb
@@ -28,10 +28,10 @@ class Chef
           end
 
           option :vault_mode,
-            :short => "-M MODE",
-            :long => "--mode MODE",
-            :description => "Chef mode to run in default - solo",
-            :proc => proc { |i| Chef::Config[:knife][:vault_mode] = i }
+            short: "-M MODE",
+            long: "--mode MODE",
+            description: "Chef mode to run in default - solo",
+            proc: proc { |i| Chef::Config[:knife][:vault_mode] = i }
         end
       end
 

--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -27,33 +27,33 @@ class Chef
       banner "knife vault create VAULT ITEM VALUES (options)"
 
       option :keys_mode,
-        :short => "-K KEYS_MODE",
-        :long => "--keys-mode KEYS_MODE",
-        :description => "Mode in which to save vault keys"
+        short: "-K KEYS_MODE",
+        long: "--keys-mode KEYS_MODE",
+        description: "Mode in which to save vault keys"
 
       option :search,
-        :short => "-S SEARCH",
-        :long => "--search SEARCH",
-        :description => "Chef SOLR search for clients"
+        short: "-S SEARCH",
+        long: "--search SEARCH",
+        description: "Chef SOLR search for clients"
 
       option :clients,
-        :short => "-C CLIENTS",
-        :long => "--clients CLIENTS",
-        :description => "Chef clients to be added as clients"
+        short: "-C CLIENTS",
+        long: "--clients CLIENTS",
+        description: "Chef clients to be added as clients"
 
       option :admins,
-        :short => "-A ADMINS",
-        :long => "--admins ADMINS",
-        :description => "Chef users to be added as admins"
+        short: "-A ADMINS",
+        long: "--admins ADMINS",
+        description: "Chef users to be added as admins"
 
       option :json,
-        :short => "-J FILE",
-        :long => "--json FILE",
-        :description => "File containing JSON data to encrypt"
+        short: "-J FILE",
+        long: "--json FILE",
+        description: "File containing JSON data to encrypt"
 
       option :file,
-        :long => "--file FILE",
-        :description => "File to be added to vault item as file-content"
+        long: "--file FILE",
+        description: "File to be added to vault item as file-content"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_edit.rb
+++ b/lib/chef/knife/vault_edit.rb
@@ -23,9 +23,9 @@ class Chef
       banner "knife vault edit VAULT ITEM (options)"
 
       option :mode,
-        :short => "-M MODE",
-        :long => "--mode MODE",
-        :description => "Chef mode to run in default - solo"
+        short: "-M MODE",
+        long: "--mode MODE",
+        description: "Chef mode to run in default - solo"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_isvault.rb
+++ b/lib/chef/knife/vault_isvault.rb
@@ -23,9 +23,9 @@ class Chef
       banner "knife vault isvault VAULT ITEM (options)"
 
       option :mode,
-        :short => "-M MODE",
-        :long => "--mode MODE",
-        :description => "Chef mode to run in default - solo"
+        short: "-M MODE",
+        long: "--mode MODE",
+        description: "Chef mode to run in default - solo"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_itemtype.rb
+++ b/lib/chef/knife/vault_itemtype.rb
@@ -23,9 +23,9 @@ class Chef
       banner "knife vault itemtype VAULT ITEM (options)"
 
       option :mode,
-        :short => "-M MODE",
-        :long => "--mode MODE",
-        :description => "Chef mode to run in default - solo"
+        short: "-M MODE",
+        long: "--mode MODE",
+        description: "Chef mode to run in default - solo"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_list.rb
+++ b/lib/chef/knife/vault_list.rb
@@ -23,9 +23,9 @@ class Chef
       banner "knife vault list (options)"
 
       option :mode,
-        :short => "-M MODE",
-        :long => "--mode MODE",
-        :description => "Chef mode to run in default - solo"
+        short: "-M MODE",
+        long: "--mode MODE",
+        description: "Chef mode to run in default - solo"
 
       def run
         set_mode(config[:vault_mode])

--- a/lib/chef/knife/vault_refresh.rb
+++ b/lib/chef/knife/vault_refresh.rb
@@ -23,12 +23,12 @@ class Chef
       banner "knife vault refresh VAULT ITEM"
 
       option :clean_unknown_clients,
-        :long => "--clean-unknown-clients",
-        :description => "Remove unknown clients during refresh"
+        long: "--clean-unknown-clients",
+        description: "Remove unknown clients during refresh"
 
       option :skip_reencryption,
-        :long => "--skip-reencryption",
-        :description => "Skip reencrypt symetrical key for existing clients/admins."
+        long: "--skip-reencryption",
+        description: "Skip reencrypt symetrical key for existing clients/admins."
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_remove.rb
+++ b/lib/chef/knife/vault_remove.rb
@@ -25,23 +25,23 @@ class Chef
       banner "knife vault remove VAULT ITEM VALUES (options)"
 
       option :search,
-        :short => "-S SEARCH",
-        :long => "--search SEARCH",
-        :description => "Chef SOLR search for clients"
+        short: "-S SEARCH",
+        long: "--search SEARCH",
+        description: "Chef SOLR search for clients"
 
       option :clients,
-        :short => "-C CLIENTS",
-        :long => "--clients CLIENTS",
-        :description => "Chef clients to be added as clients"
+        short: "-C CLIENTS",
+        long: "--clients CLIENTS",
+        description: "Chef clients to be added as clients"
 
       option :admins,
-        :short => "-A ADMINS",
-        :long => "--admins ADMINS",
-        :description => "Chef users to be added as admins"
+        short: "-A ADMINS",
+        long: "--admins ADMINS",
+        description: "Chef users to be added as admins"
 
       option :clean_unknown_clients,
-        :long => "--clean-unknown-clients",
-        :description => "Remove unknown clients during key rotation"
+        long: "--clean-unknown-clients",
+        description: "Remove unknown clients during key rotation"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_rotate_all_keys.rb
+++ b/lib/chef/knife/vault_rotate_all_keys.rb
@@ -23,8 +23,8 @@ class Chef
       banner "knife vault rotate all keys"
 
       option :clean_unknown_clients,
-        :long => "--clean-unknown-clients",
-        :description => "Remove unknown clients during key rotation"
+        long: "--clean-unknown-clients",
+        description: "Remove unknown clients during key rotation"
 
       def run
         clean_unknown_clients = config[:clean_unknown_clients]

--- a/lib/chef/knife/vault_rotate_keys.rb
+++ b/lib/chef/knife/vault_rotate_keys.rb
@@ -23,8 +23,8 @@ class Chef
       banner "knife vault rotate keys VAULT ITEM (options)"
 
       option :clean_unknown_clients,
-        :long => "--clean-unknown-clients",
-        :description => "Remove unknown clients during key rotation"
+        long: "--clean-unknown-clients",
+        description: "Remove unknown clients during key rotation"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_show.rb
+++ b/lib/chef/knife/vault_show.rb
@@ -23,14 +23,14 @@ class Chef
       banner "knife vault show VAULT [ITEM] [VALUES] (options)"
 
       option :mode,
-        :short => "-M MODE",
-        :long => "--mode MODE",
-        :description => "Chef mode to run in default - solo"
+        short: "-M MODE",
+        long: "--mode MODE",
+        description: "Chef mode to run in default - solo"
 
       option :print,
-        :short => "-p TYPE",
-        :long => "--print TYPE",
-        :description => "Print extra vault data, can be search, admins, clients or all"
+        short: "-p TYPE",
+        long: "--print TYPE",
+        description: "Print extra vault data, can be search, admins, clients or all"
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_update.rb
+++ b/lib/chef/knife/vault_update.rb
@@ -27,32 +27,32 @@ class Chef
       banner "knife vault update VAULT ITEM VALUES (options)"
 
       option :search,
-        :short => "-S SEARCH",
-        :long => "--search SEARCH",
-        :description => "Chef SOLR search for clients"
+        short: "-S SEARCH",
+        long: "--search SEARCH",
+        description: "Chef SOLR search for clients"
 
       option :clients,
-        :short => "-C CLIENTS",
-        :long => "--clients CLIENTS",
-        :description => "Chef clients to be added as clients"
+        short: "-C CLIENTS",
+        long: "--clients CLIENTS",
+        description: "Chef clients to be added as clients"
 
       option :admins,
-        :short => "-A ADMINS",
-        :long => "--admins ADMINS",
-        :description => "Chef users to be added as admins"
+        short: "-A ADMINS",
+        long: "--admins ADMINS",
+        description: "Chef users to be added as admins"
 
       option :json,
-        :short => "-J FILE",
-        :long => "--json FILE",
-        :description => "File containing JSON data to encrypt"
+        short: "-J FILE",
+        long: "--json FILE",
+        description: "File containing JSON data to encrypt"
 
       option :file,
-        :long => "--file FILE",
-        :description => "File to be added to vault item as file-content"
+        long: "--file FILE",
+        description: "File to be added to vault item as file-content"
 
       option :clean,
-        :long => "--clean",
-        :description => "Clean clients before performing search"
+        long: "--clean",
+        description: "Clean clients before performing search"
 
       def run
         vault = @name_args[0]

--- a/spec/chef-vault/chef_api_spec.rb
+++ b/spec/chef-vault/chef_api_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe ChefVault::ChefApi do
   let(:root_url) { "https://localhost" }
   let(:scoped_url) { "https://localhost/organizations/fakeorg" }
-  let(:api_v0_hash) { { :api_version => "0" } }
-  let(:api_v1_hash) { { :api_version => "1" } }
+  let(:api_v0_hash) { { api_version: "0" } }
+  let(:api_v1_hash) { { api_version: "1" } }
 
   before do
     Chef::Config[:chef_server_root] = root_url

--- a/spec/chef-vault/item_keys_spec.rb
+++ b/spec/chef-vault/item_keys_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ChefVault::ItemKeys do
 
           it "removes the actor's name from the data bag and from the array for the actor's type" do
             keys.delete(chef_key)
-            expect(keys.has_key?(chef_key.name)).to eq(false)
+            expect(keys.key?(chef_key.name)).to eq(false)
             expect(keys[type].include?(name)).to eq(false)
             expect(keys.include?(name)).to eq(false)
           end


### PR DESCRIPTION
Set the Rubocop config to assess based on Ruby 2.2 until such time as it's decided that chef-vault bumps a major version and doesn't support Chef versions that ship with Ruby below 2.3.

Offenses:

| Count | Cop |
| ------ | ---- |
| 82 | Style/HashSyntax |
| 2 | Layout/LeadingCommentSpace |
| 1 | Style/MutableConstant |
| 1 | Style/PreferredHashMethods |
| **86** | **Total** |

Also, update Travis config to run latest point releases of Ruby.