### PR TITLE
Don't ship the readme in the gem

### DIFF
--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.description      = s.summary
   s.homepage         = "https://github.com/chef/chef-vault"
   s.license          = "Apache-2.0"
-  s.files            = %w{LICENSE README.md Gemfile} + Dir.glob("*.gemspec") + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:bin/|lib/)}i }
+  s.files            = %w{LICENSE Gemfile} + Dir.glob("*.gemspec") + `git ls-files`.split("\n").select { |f| f =~ %r{^(?:bin/|lib/)}i }
   s.require_paths    = ["lib"]
   s.bindir           = "bin"
   s.executables      = %w{ chef-vault }


### PR DESCRIPTION
There's no need for this in a gem. It just make the install that much
bigger.

Signed-off-by: Tim Smith <tsmith@chef.io>