### PR TITLE
Send a better error message when an invalid SSL key is encountered when creating a vault item

### DIFF
--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -69,7 +69,11 @@ class ChefVault
               "cannot manage a v1 vault.  See UPGRADE.md for help"
       end
       @cache[chef_key.name] = skip_reencryption ? self[chef_key.name] : nil
-      @cache[chef_key.name] ||= ChefVault::ItemKeys.encode_key(chef_key.key, data_bag_shared_secret)
+      begin
+        @cache[chef_key.name] ||= ChefVault::ItemKeys.encode_key(chef_key.key, data_bag_shared_secret)
+      rescue OpenSSL::PKey::RSAError
+        raise OpenSSL::PKey::RSAError, "While adding #{chef_key.type} an invalid or old (pre chef-server 12) format public key was found for #{chef_key.name}"
+      end
       @raw_data[type] << chef_key.name unless @raw_data[type].include?(chef_key.name)
       @raw_data[type]
     end


### PR DESCRIPTION
When creating a vault item we get an OpenSSL::PKey::RSAError error when the user or client
keys were generated from a version of chef-server before chef-server 12. The error raised
has no useful information for solving the problem. Pre chef-server 12
public keys are certificates instead of public keys. This change identifies the
user or client with an invalid public key. The key needs to be recreated, any existing
vault items used by the server need to be refreshed after the key is generated.

### Description

Creates an error message that can be used.

### Issues Resolved

[List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant]

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
