### PR TITLE
Ensure search is not empty when refreshing

### DIFF
--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -358,12 +358,12 @@ class ChefVault
     #   no longer be found
     # @return [void]
     def refresh(clean_unknown_clients = false)
-      unless search
+      if search.empty?
         raise ChefVault::Exceptions::SearchNotFound,
-              "#{vault}/#{item} does not have a stored search_query, "\
-              "probably because it was created with an older version "\
-              "of chef-vault. Use 'knife vault update' to update the "\
-              "databag with the search query."
+              "#{@data_bag}/#{@raw_data["id"]} does not have a stored "\
+              "search_query, probably because it was created with an "\
+              "older version of chef-vault. Use 'knife vault update' "\
+              "to update the databag with the search query."
       end
 
       # a bit of a misnomer; this doesn't remove unknown


### PR DESCRIPTION
### Description

An empty array or an empty string is not considered false
so no exception is raised when item.search is empty. Which
means we get an HTTP error instead of the expected exception.

This change checks if search is empty instead of just checking if it the false value.

### Issues Resolved

Fixes #312 

### Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [X] All commits have been signed-off for the Developer Certificate of Origin. See <https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
- [X] PR title is a worthy inclusion in the CHANGELOG