### PR TITLE
Rescue HTTP events properly in Ruby 2.6+

### DIFF
--- a/lib/chef-vault/actor.rb
+++ b/lib/chef-vault/actor.rb
@@ -39,7 +39,7 @@ class ChefVault
     def get_admin_key
       # chef vault currently only supports using the default key
       get_key("users")
-    rescue Net::HTTPServerException => http_error
+    rescue Net::HTTPServerException, Net::HTTPClientException => http_error
       # if we failed to find an admin key, attempt to load a client key by the same name
       case http_error.response.code
       when "403"
@@ -49,7 +49,7 @@ class ChefVault
         begin
           ChefVault::Log.warn "The default key for #{name} not found in users, trying client keys."
           get_key("clients")
-        rescue Net::HTTPServerException => http_error
+        rescue Net::HTTPServerException, Net::HTTPClientException => http_error
           case http_error.response.code
           when "404"
             raise ChefVault::Exceptions::AdminNotFound,
@@ -68,7 +68,7 @@ class ChefVault
 
     def get_client_key
       get_key("clients")
-    rescue Net::HTTPServerException => http_error
+    rescue Net::HTTPServerException, Net::HTTPClientException => http_error
       if http_error.response.code.eql?("403")
         print_forbidden_error
         raise http_error
@@ -114,7 +114,7 @@ class ChefVault
     def get_key(request_actor_type)
       api.org_scoped_rest_v1.get("#{request_actor_type}/#{name}/keys/default").fetch("public_key")
     # If the keys endpoint doesn't exist, try getting it directly from the V0 chef object.
-    rescue Net::HTTPServerException => http_error
+    rescue Net::HTTPServerException, Net::HTTPClientException => http_error
       raise http_error unless http_error.response.code.eql?("404")
 
       if request_actor_type.eql?("clients")

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -229,7 +229,7 @@ class ChefVault
       else
         begin
           Chef::DataBag.load(data_bag)
-        rescue Net::HTTPServerException => http_error
+        rescue Net::HTTPServerException, Net::HTTPClientException => http_error
           if http_error.response.code == "404"
             chef_data_bag = Chef::DataBag.new
             chef_data_bag.name data_bag
@@ -293,7 +293,7 @@ class ChefVault
       begin
         item.raw_data =
           Chef::EncryptedDataBagItem.load(vault, name, item.secret).to_hash
-      rescue Net::HTTPServerException => http_error
+      rescue Net::HTTPServerException, Net::HTTPClientException => http_error
         if http_error.response.code == "404"
           raise ChefVault::Exceptions::ItemNotFound,
             "#{vault}/#{name} could not be found"
@@ -436,7 +436,7 @@ class ChefVault
     def client_exists?(clientname)
       Chef::ApiClient.load(clientname)
       true
-    rescue Net::HTTPServerException => http_error
+    rescue Net::HTTPServerException, Net::HTTPClientException => http_error
       return false if http_error.response.code == "404"
 
       raise http_error

--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -122,7 +122,7 @@ class ChefVault
       unless Chef::Config[:solo_legacy_mode]
         begin
           Chef::DataBag.load(data_bag)
-        rescue Net::HTTPServerException => http_error
+        rescue Net::HTTPServerException, Net::HTTPClientException => http_error
           if http_error.response.code == "404"
             chef_data_bag = Chef::DataBag.new
             chef_data_bag.name data_bag
@@ -143,7 +143,7 @@ class ChefVault
               Chef::DataBagItem.from_hash("data_bag" => data_bag,
                                           "id" => sparse_id(key))
                 .destroy(data_bag, sparse_id(key))
-            rescue Net::HTTPServerException => http_error
+            rescue Net::HTTPServerException, Net::HTTPClientException => http_error
               raise http_error unless http_error.response.code == "404"
             end
           end
@@ -234,7 +234,7 @@ class ChefVault
     def self.load(vault, name)
       begin
         data_bag_item = Chef::DataBagItem.load(vault, name)
-      rescue Net::HTTPServerException => http_error
+      rescue Net::HTTPServerException, Net::HTTPClientException => http_error
         if http_error.response.code == "404"
           raise ChefVault::Exceptions::KeysNotFound,
             "#{vault}/#{name} could not be found"
@@ -265,7 +265,7 @@ class ChefVault
       else
         begin
           Chef::DataBagItem.load(@data_bag, sid)
-        rescue Net::HTTPServerException => http_error
+        rescue Net::HTTPServerException, Net::HTTPClientException => http_error
           nil if http_error.response.code == "404"
         end
       end


### PR DESCRIPTION
Ruby 2.6 renamed the http error class. Make sure we rescue the one that
will actually get raised.

Signed-off-by: Tim Smith <tsmith@chef.io>