### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/chef-vault/actor.rb
+++ b/lib/chef-vault/actor.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "json"
+require "json" unless defined?(JSON)
 
 class ChefVault
   class Actor

--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require "securerandom"
+require "securerandom" unless defined?(SecureRandom)
 require_relative "mixins"
 
 class ChefVault


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>