### PR TITLE
Optimize split_vault_keys method for large bag

### DIFF
--- a/bin/chef-vault
+++ b/bin/chef-vault
@@ -79,7 +79,7 @@ options_config.each do |option, config|
 end
 
 options_config.each do |option, config|
-  options[option] = options[option] ? options[option] : config[:default]
+  options[option] ||= config[:default]
 end
 
 require "rubygems" unless defined?(Gem)

--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$:.push File.expand_path("../lib", __FILE__)
+$:.push File.expand_path("lib", __dir__)
 require "chef-vault/version"
 
 Gem::Specification.new do |s|

--- a/lib/chef/knife/vault_admins.rb
+++ b/lib/chef/knife/vault_admins.rb
@@ -26,7 +26,7 @@ class Chef
         vault_admins = Chef::Config[:knife][:vault_admins]
         admin_array = [Chef::Config[:node_name]]
 
-        if !vault_admins.kind_of?(Array)
+        unless vault_admins.is_a?(Array)
           ui.warn("Vault admin must be an array")
         end
 

--- a/lib/chef/knife/vault_base.rb
+++ b/lib/chef/knife/vault_base.rb
@@ -24,7 +24,7 @@ class Chef
         includer.class_eval do
           deps do
             require "chef/search/query"
-            require File.expand_path("../mixin/helper", __FILE__)
+            require File.expand_path("mixin/helper", __dir__)
             include ChefVault::Mixin::Helper
           end
 


### PR DESCRIPTION
## Description

With 10k secrets the regexp union is quite big and applying it to the 20k keys takes around 2 minutes...
Also the Regexp was too greedy and could match normal items as sparse one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
