### PR TITLE
Fix multiple requests to Chef server

### DIFF
--- a/lib/chef-vault/item.rb
+++ b/lib/chef-vault/item.rb
@@ -160,10 +160,11 @@ class ChefVault
     end
 
     def secret
-      if @keys.include?(@node_name) && !@keys[@node_name].nil?
+      t = @keys[@node_name]
+      if !t.nil?
         private_key = OpenSSL::PKey::RSA.new(File.open(@client_key_path).read)
         begin
-          private_key.private_decrypt(Base64.decode64(@keys[@node_name]))
+          private_key.private_decrypt(Base64.decode64(t))
         rescue OpenSSL::PKey::RSAError
           raise ChefVault::Exceptions::SecretDecryption,
             "#{data_bag}/#{id} is encrypted for you, but your private key failed to decrypt the contents.  "\

--- a/lib/chef-vault/item_keys.rb
+++ b/lib/chef-vault/item_keys.rb
@@ -34,9 +34,12 @@ class ChefVault
       @raw_data["search_query"] = []
       @raw_data["mode"] = "default"
       @cache = {} # write-back cache for keys
+      @tmpcache = nil
     end
 
     def [](key)
+      # return if cache contents is not empty
+      return @tmpcache unless @tmpcache.nil?
       # return options immediately
       return @raw_data[key] if %w{id admins clients search_query mode}.include?(key)
 
@@ -47,6 +50,7 @@ class ChefVault
       # check if the key is saved in sparse mode
       skey = sparse_key(sparse_id(key)) if sparse?
       if skey
+        @tmpcache = skey[key]
         skey[key]
       else
         # fallback to raw data
@@ -89,6 +93,7 @@ class ChefVault
 
     def delete(chef_key)
       @cache[chef_key.name] = false
+      @tmpcache = nil
       raw_data[chef_key.type].delete(chef_key.name)
       raw_data.delete(chef_key.name)
     end


### PR DESCRIPTION
Reduce the number of requests to Chef server for secrets in sparse mode.
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
We noticed that when loading a secret in sparse mode, chef-vault makes as much as six requests to Chef server while retrieving the client's data bag encryption key, which is caused by multiple calls of `sparse_key` method. These changes reduce the number of such requests to one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
