### PR TITLE
Replaced exception with the warnings and removed related failing specs(used earlier for raising issue)

### DIFF
--- a/lib/chef/knife/mixin/helper.rb
+++ b/lib/chef/knife/mixin/helper.rb
@@ -59,7 +59,7 @@ class ChefVault
             next unless printable?(value.to_s)
 
             msg = "Value '#{value}' of key '#{key}' contains non-printable characters. Check that backslashes are escaped with another backslash (e.g. C:\\\\Windows) in double-quoted strings."
-            raise ChefVault::Exceptions::InvalidValue, msg
+            ChefVault::Log.warn(msg)
           end
         end
       end

--- a/lib/chef/knife/mixin/helper.rb
+++ b/lib/chef/knife/mixin/helper.rb
@@ -69,7 +69,7 @@ class ChefVault
       # returns true if string is free of non-printable characters (escape sequences)
       # this returns false for whitespace escape sequences as well, e.g. \n\t
       def printable?(string)
-        /[^[:print:]]/.match(string)
+        /[^[:print:]]|[[:space:]]/.match(string)
       end
     end
   end

--- a/spec/chef/helper_spec.rb
+++ b/spec/chef/helper_spec.rb
@@ -5,16 +5,11 @@ RSpec.describe ChefVault::Mixin::Helper do
   include ChefVault::Mixin::Helper
 
   let(:json_data) { '{"username": "root", "password": "abcabc"}' }
-  let(:json_data_control_char) { '{"username": "root", "password": "abc\abc"}' }
   let(:buggy_json_data) { '{"username": "root", "password": "abc\abc"' }
 
   describe "#validate_json" do
     it "Raises InvalidValue Exception when invalid data provided" do
       expect { validate_json(buggy_json_data) }.to raise_error(ChefVault::Exceptions::InvalidValue)
-    end
-
-    it "Raises InvalidValue Exception when value consist of control characters" do
-      expect { validate_json(json_data_control_char) }.to raise_error(ChefVault::Exceptions::InvalidValue)
     end
 
     it "Not to raise error if valid data provided" do

--- a/spec/chef/helper_spec.rb
+++ b/spec/chef/helper_spec.rb
@@ -4,6 +4,7 @@ require "chef/knife/mixin/helper"
 RSpec.describe ChefVault::Mixin::Helper do
   include ChefVault::Mixin::Helper
 
+  let(:json) { { "username": "root" } }
   let(:json_data) { '{"username": "root", "password": "abcabc"}' }
   let(:buggy_json_data) { '{"username": "root", "password": "abc\abc"' }
 
@@ -14,6 +15,13 @@ RSpec.describe ChefVault::Mixin::Helper do
 
     it "Not to raise error if valid data provided" do
       expect { validate_json(json_data) }.to_not raise_error
+    end
+
+    it "not to raise error if data consist of tab/new line OR space" do
+      %w{abc\tabc abc\nabc}.each do |pass|
+        json_data_with_slash = json.merge("password": pass)
+        expect { validate_json(json_data_with_slash.to_s) }.to_not raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: sanga17 <sausekar@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
When uploading vault item that contains \n errors with the below message.

Check that backslashes are escaped with another backslash (e.g. C:\Windows) in double-quoted strings.
Looking at that error, we changed the \n to \n and the error stops BUT the content vault item actually have \n and no new line is inserted.

Before Fix: 
```
bundle exec knife vault update test test1 -J ../../chef-repo/root.json -c ../../chef-repo/.chef/knife.rb
ERROR: ChefVault::Exceptions::InvalidValue: Value 'my
     passwords' of key 'text1' contains non-printable characters. Check that backslashes are escaped with another backslash (e.g. C:\\Windows) in double-quoted strings.

bundle exec knife vault show test test1 -c ../../chef-repo/.chef/knife.rb
id:       test1
text1:    my\npasswords
username: root

```
After Fix:
``` 
bundle exec knife vault update test test1 -J ../../chef-repo/root.json -c ../../chef-repo/.chef/knife.rb
WARN: Value 'my
passwordsj' of key 'text1' contains non-printable characters. Check that backslashes are escaped with another backslash (e.g. C:\\Windows) in double-quoted strings.


bundle exec knife vault show test test1 -c ../../chef-repo/.chef/knife.rb
id:       test1
text1:    my
passwords
username: root
```
## Related Issue
Fixed: https://github.com/chef/chef-vault/issues/366

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
