### PR TITLE
Allow Whitespace Characters as Vault Content

### DIFF
--- a/lib/chef/knife/mixin/helper.rb
+++ b/lib/chef/knife/mixin/helper.rb
@@ -66,10 +66,10 @@ class ChefVault
 
       # I/P: String
       # O/P: true/false
-      # returns true if string is free of non-printable characters (escape sequences)
-      # this returns false for whitespace escape sequences as well, e.g. \n\t
+      # returns true if string is free of non-printable and whitespace characters
+      # (escape sequences)
       def printable?(string)
-        /[^[:print:]]/.match(string)
+        /[^[:graph:][:space:]]/.match(string)
       end
     end
   end

--- a/spec/chef/helper_spec.rb
+++ b/spec/chef/helper_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ChefVault::Mixin::Helper do
   include ChefVault::Mixin::Helper
 
   let(:json_data) { '{"username": "root", "password": "abcabc"}' }
+  let(:json_data_whitespace) { '{"username": "root", "password": "abc\nabc\tabc"}' }
   let(:json_data_control_char) { '{"username": "root", "password": "abc\abc"}' }
   let(:buggy_json_data) { '{"username": "root", "password": "abc\abc"' }
 
@@ -19,6 +20,10 @@ RSpec.describe ChefVault::Mixin::Helper do
 
     it "Not to raise error if valid data provided" do
       expect { validate_json(json_data) }.to_not raise_error
+    end
+
+    it "Not to raise error if valid data with whitespace provided" do
+      expect { validate_json(json_data_whitespace) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
This change allows to use line breaks `\n` and tabs `\t` as characters in the content of a vault.

## Description

Disallowing line breaks (and possibly tabs) renders Chef Vaults unusable for X.509 and SSH keys. This commit include these character in the set of allowed characters.

Please keep in mind this change only makes SSH and X.509 keys to work again. There are some cases where it is convenient to store binary data in vaults. Think of PKCS#12 files, Kerberos Keytabs, or unarmored OpenPGP keys for example. Given that it would be worth questioning the changes of #347, which introduced this changes behaviour.

## Related Issue

* #370 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:

- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
