### PR TITLE
Avoid loading all of chef-vault unless we're running the plugin

### DIFF
--- a/lib/chef/knife/vault_create.rb
+++ b/lib/chef/knife/vault_create.rb
@@ -14,15 +14,11 @@
 # limitations under the License.
 
 require_relative "vault_base"
-require_relative "vault_admins"
-require_relative "vault_clients"
 
 class Chef
   class Knife
     class VaultCreate < Knife
       include Chef::Knife::VaultBase
-      include Chef::Knife::VaultAdmins
-      include Chef::Knife::VaultClients
 
       banner "knife vault create VAULT ITEM VALUES (options)"
 
@@ -54,6 +50,13 @@ class Chef
       option :file,
         long: "--file FILE",
         description: "File to be added to vault item as file-content"
+
+      deps do
+        require_relative "vault_admins"
+        require_relative "vault_clients"
+        include Chef::Knife::VaultAdmins
+        include Chef::Knife::VaultClients
+      end
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_remove.rb
+++ b/lib/chef/knife/vault_remove.rb
@@ -14,13 +14,11 @@
 # limitations under the License.
 
 require_relative "vault_base"
-require_relative "vault_clients"
 
 class Chef
   class Knife
     class VaultRemove < Knife
       include Chef::Knife::VaultBase
-      include Chef::Knife::VaultClients
 
       banner "knife vault remove VAULT ITEM VALUES (options)"
 
@@ -42,6 +40,11 @@ class Chef
       option :clean_unknown_clients,
         long: "--clean-unknown-clients",
         description: "Remove unknown clients during key rotation"
+
+      deps do
+        require_relative "vault_clients"
+        include Chef::Knife::VaultClients
+      end
 
       def run
         vault = @name_args[0]

--- a/lib/chef/knife/vault_update.rb
+++ b/lib/chef/knife/vault_update.rb
@@ -14,15 +14,11 @@
 # limitations under the License.
 
 require_relative "vault_base"
-require_relative "vault_admins"
-require_relative "vault_clients"
 
 class Chef
   class Knife
     class VaultUpdate < Knife
       include Chef::Knife::VaultBase
-      include Chef::Knife::VaultAdmins
-      include Chef::Knife::VaultClients
 
       banner "knife vault update VAULT ITEM VALUES (options)"
 
@@ -58,6 +54,13 @@ class Chef
         short: "-K KEYS_MODE",
         long: "--keys-mode KEYS_MODE",
         description: "Mode in which to save vault keys"
+
+      deps do
+        require_relative "vault_admins"
+        require_relative "vault_clients"
+        include Chef::Knife::VaultAdmins
+        include Chef::Knife::VaultClients
+      end
 
       def run
         vault = @name_args[0]


### PR DESCRIPTION
Right now any knife plugin even `knife -h` will load all these plugins and end up loading all of chef-vault. This avoids 11 requires total.

Signed-off-by: Tim Smith <tsmith@chef.io>