### PR TITLE
add support for client_key_contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ instead.
 
 Normally, the value of `Chef::Config[:node_name]` is used to find the
 per-node encrypted secret in the keys data bag item, and the value of
-`Chef::Config[:client_key]` is used to locate the private key or
-`Chef::Config[:client_key_contents]` to decrypt this secret.
+`Chef::Config[:client_key]` is used to locate the private key to decrypt
+this secret. If `Chef::Config[:client_key_contents]` is defined, it takes
+precedence over the file path specified in `Chef::Config[:client_key]`.
 
 These can be overridden by passing a hash with the keys `:node_name` or
 `:client_key_path` to `ChefVault::Item.load`:

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ instead.
 
 Normally, the value of `Chef::Config[:node_name]` is used to find the
 per-node encrypted secret in the keys data bag item, and the value of
-`Chef::Config[:client_key]` is used to locate the private key to decrypt
-this secret.
+`Chef::Config[:client_key]` is used to locate the private key or
+`Chef::Config[:client_key_contents]` to decrypt this secret.
 
 These can be overridden by passing a hash with the keys `:node_name` or
 `:client_key_path` to `ChefVault::Item.load`:

--- a/features/step_definitions/chef-repo.rb
+++ b/features/step_definitions/chef-repo.rb
@@ -34,6 +34,10 @@ Given(/^I create an admin named '(.+)'$/) do |admin|
   create_admin(admin)
 end
 
+Given(/^I create( mismatched)? client config for client named '(.+)'$/) do |mismatched, client|
+  create_client_config(client, mismatched)
+end
+
 Given(/^I delete clients? '(.+)' from the Chef server$/) do |nodelist|
   nodelist.split(/,/).each do |node|
     delete_client(node)
@@ -69,4 +73,19 @@ end
 
 def delete_node(name)
   run_command_and_stop "knife node delete #{name} -y -z -c config.rb"
+end
+
+def create_client_config(name, mismatched = false)
+  content = <<EOF
+local_mode true
+chef_repo_path '.'
+chef_zero.enabled true
+knife[:vault_mode] = 'client'
+node_name '#{name}'
+client_key_contents IO.read('#{name}.pem')
+EOF
+  write_file("config_#{name}.rb", content)
+  if mismatched
+    append_to_file "config_#{name}.rb", "client_key 'admin.pem'"
+  end
 end

--- a/features/step_definitions/chef-vault.rb
+++ b/features/step_definitions/chef-vault.rb
@@ -101,8 +101,12 @@ Given(/^I list the vaults$/) do
   run_command_and_stop("knife vault list")
 end
 
-Given(%r{^I can('t)? decrypt the vault item '(.+)/(.+)' as '(.+)'$}) do |neg, vault, item, client|
-  run_command_and_stop "knife vault show #{vault} #{item} -c config.rb -z -u #{client} -k #{client}.pem", { fail_on_error: false }
+Given(%r{^I can('t)? decrypt the vault item '(.+)/(.+)' as '(.+)'( using client config)?$}) do |neg, vault, item, client, client_config|
+  if client_config
+    run_command_and_stop "knife vault show #{vault} #{item} -c config_#{client}.rb -z -u #{client}", { fail_on_error: false }
+  else
+    run_command_and_stop "knife vault show #{vault} #{item} -c config.rb -z -u #{client} -k #{client}.pem", { fail_on_error: false }
+  end
   if neg
     expect(last_command_started).not_to have_exit_status(0)
   else

--- a/features/vault_show.feature
+++ b/features/vault_show.feature
@@ -14,6 +14,19 @@ Feature: knife vault show
     And I can decrypt the vault item 'test/item' as 'alice'
     And the output should match /^foo: bar$/
 
+  Scenario: successful decrypt as admin using client_key_contents
+    Given a local mode chef repo with nodes 'one,two,three' with admins 'alice,bob'
+    Given I create client config for client named 'alice'
+    Given I create mismatched client config for client named 'bob'
+    And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three' with 'alice,bob' as admins
+    Then the vault item 'test/item' should be encrypted for 'alice,bob'
+    And 'one,two,three' should be a client for the vault item 'test/item'
+    And 'alice' should be an admin for the vault item 'test/item'
+    And 'bob' should be an admin for the vault item 'test/item'
+    And I can decrypt the vault item 'test/item' as 'alice' using client config
+    And I can decrypt the vault item 'test/item' as 'bob' using client config
+    And the output should match /^foo: bar$/
+
   Scenario: successful decrypt as node
     Given a local mode chef repo with nodes 'one,two,three' with admins 'alice,bob'
     And I create a vault item 'test/item' containing the JSON '{"foo": "bar"}' encrypted for 'one,two,three' with 'alice' as admin

--- a/spec/chef-vault/item_spec.rb
+++ b/spec/chef-vault/item_spec.rb
@@ -121,6 +121,11 @@ RSpec.describe ChefVault::Item do
       expect(item.client_key_path).to eq(Chef::Config[:client_key])
     end
 
+    it "defaults the client key contents" do
+      item = ChefVault::Item.new("foo", "bar")
+      expect(item.client_key_contents).to eq(Chef::Config[:client_key_contents])
+    end
+
     it "allows for a node name override" do
       item = ChefVault::Item.new("foo", "bar", node_name: "baz")
       expect(item.node_name).to eq("baz")
@@ -131,6 +136,11 @@ RSpec.describe ChefVault::Item do
       expect(item.client_key_path).to eq("/foo/client.pem")
     end
 
+    it "allows for a client key contents override" do
+      item = ChefVault::Item.new("foo", "bar", client_key_contents: "baz")
+      expect(item.client_key_contents).to eq("baz")
+    end
+
     it "allows for both node name and client key overrides" do
       item = ChefVault::Item.new(
         "foo", "bar",
@@ -139,6 +149,18 @@ RSpec.describe ChefVault::Item do
       )
       expect(item.node_name).to eq("baz")
       expect(item.client_key_path).to eq("/foo/client.pem")
+    end
+
+    it "allows for node name, client key and client key contents overrides" do
+      item = ChefVault::Item.new(
+        "foo", "bar",
+        node_name: "baz",
+        client_key_path: "/foo/client.pem",
+        client_key_contents: "qux"
+      )
+      expect(item.node_name).to eq("baz")
+      expect(item.client_key_path).to eq("/foo/client.pem")
+      expect(item.client_key_contents).to eq("qux")
     end
   end
 


### PR DESCRIPTION
## Description
adds support for chef-vault to use the private key from the client_key_contents chef configuration option

## Related Issue
#401 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
