### PR TITLE
Fixing windows verify pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,10 @@ group :development do
     gem "chef-utils", "17.10.68" # pin until we drop ruby 2.5
   else
     gem "contracts", "~> 0.17"
-    gem "chef-zero", ">= 15.0.4"
+    gem "chef-zero", "~> 15.0"
     gem "chef", ">= 18.5.0"
     gem "rspec", "~> 3.0"
-    gem "aruba", "~> 2.2"
+    gem "aruba", "~> 2.3"
     gem "knife", "~> 18.0"
     gem "chef-utils", ">= 18.5.0" # pin until we drop ruby >=3
   end

--- a/features/step_definitions/chef-repo.rb
+++ b/features/step_definitions/chef-repo.rb
@@ -62,9 +62,11 @@ def create_admin(admin)
 end
 
 def create_client(name)
-  command = "knife client create #{name} -z -d -c config.rb >#{name}.pem"
-  run_command_and_stop command
-  write_file("#{name}.pem", last_command_started.stdout)
+  command = "knife client create #{name} -z -d -c config.rb"
+  pem_file = "#{name}.pem"
+
+  run_command_and_stop(command)
+  write_file(pem_file, last_command_started.stdout)
 end
 
 def delete_client(name)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,7 +4,13 @@ require "aruba/cucumber"
 # the knife command.  Up the timeout when we're in a travis build based on the
 # environment variable set in .travis.yml
 # if ENV['TRAVIS_BUILD']
-Before do
-  @aruba_timeout_seconds = 15
+Aruba.configure do |config|
+  if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
+    config.exit_timeout = 30
+  else
+    config.exit_timeout = 15
+  end
+
+  config.activate_announcer_on_command_failure = %i{stderr stdout command}
 end
 # end


### PR DESCRIPTION
## Description

`@aruba_timeout_seconds` is depreciated so updated the code with latest Aruba configuration to set the timeout.
Also updated the timeout for windows platform since the cucumber scenarios take more time execution in the windows platform.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
