### PR TITLE
Updating the timeout for the verify pipeline to 120 min

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -7,7 +7,7 @@ expeditor:
       retry:
         automatic:
           limit: 1
-      timeout_in_minutes: 60
+      timeout_in_minutes: 120
 
 steps:
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ require "aruba/cucumber"
 # if ENV['TRAVIS_BUILD']
 Aruba.configure do |config|
   if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
-    config.exit_timeout = 40
+    config.exit_timeout = 60
   else
     config.exit_timeout = 15
   end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ require "aruba/cucumber"
 # if ENV['TRAVIS_BUILD']
 Aruba.configure do |config|
   if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
-    config.exit_timeout = 30
+    config.exit_timeout = 40
   else
     config.exit_timeout = 15
   end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Updating the timeout for the verify pipeline to 120 min

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
