### PR TITLE
Remove Ruby version conditional logic for syslog from gemspec

### DIFF
--- a/chef-vault.gemspec
+++ b/chef-vault.gemspec
@@ -33,9 +33,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1"
 
-  # This gem was removed from the Ruby standard library starting with version 3.4
-  # See: https://stdgems.org/new-in/3.4
-  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
-    s.add_dependency "syslog", "~> 0.3"
-  end
+  # syslog was removed from Ruby's standard library in 3.4; see https://stdgems.org/new-in/3.4
+  s.add_dependency "syslog", "~> 0.3"
 end


### PR DESCRIPTION
This PR removes the Ruby version conditional logic for the syslog dependency from the gemspec file.