### PR TITLE
Updating to common GitHub Action 1.0.5

### DIFF
--- a/.github/workflows/ci-main-pull-request-stub.yml
+++ b/.github/workflows/ci-main-pull-request-stub.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
   
 env:
-  STUB_VERSION: "1.0.4" 
+  STUB_VERSION: "1.0.5"
 
 jobs: 
   echo_version:
@@ -43,6 +43,7 @@ jobs:
       version: '4.2.3' # ${{ github.event.repository.version }}
       detect-version-source-type: 'none' # options include "none" (do not detect), "file", "github-tag" or "github-release"
       detect-version-source-parameter: '' # use for file name
+      language: 'ruby'  # Go, Ruby, Rust, JavaScript, TypeScript, Python, Java, C#, PHP, other - used for build and SonarQube language setting
 
       # complexity-checks
       perform-complexity-checks: true
@@ -59,7 +60,7 @@ jobs:
       # requires these secrets: POLARIS_SERVER_URL, POLARIS_ACCESS_TOKEN
       perform-blackduck-polaris: true
       polaris-application-name: "Chef-Agents"  # one of these: Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services, Chef-Other
-      polaris-project-name: 'chef-vault'
+      polaris-project-name: ${{ github.event.repository.name }}
       polaris-blackduck-executable: 'path/to/blackduck/binary'
       polaris-executable-detect-path: 'path/to/detect'
  
@@ -75,6 +76,8 @@ jobs:
       # perform-sonar-build: true
       # build-profile: 'default' 
       # report-unit-test-coverage: true
+
+      perform-docker-scan: false  # scan Dockerfile and built images with Docker Scout or Trivy; see repo custom properties matching "container"
 
       # report to central developer dashboard
       report-to-atlassian-dashboard: false
@@ -93,7 +96,7 @@ jobs:
       # generate and export Software Bill of Materials (SBOM) in various formats
       generate-sbom: true
       export-github-sbom: true      # SPDX JSON artifact on job instance  
-      perform-blackduck-sca-scan: false # combined with generate sbom & generate github-sbom, also needs version above
+      perform-blackduck-sca-scan: true # combined with generate sbom & generate github-sbom, also needs version above
       blackduck-project-group-name: 'Chef-Agents' # typically one of (Chef), Chef-Agents, Chef-Automate, Chef-Chef360, Chef-Habitat, Chef-Infrastructure-Server, Chef-Shared-Services'
       blackduck-project-name: ${{ github.event.repository.name }} # BlackDuck project name, typically the repository name
       generate-blackduck-sbom: false # obsolete, use perform-blackduck-sca-scan instead


### PR DESCRIPTION
This pull request updates the `.github/workflows/ci-main-pull-request-stub.yml` workflow file to improve configuration flexibility and security scanning coverage. The most important changes are grouped below:

## Description
This pull request updates the CI workflow to STUB_VERSION 1.0.5 and enabled few fields like 
This pull request updates the `.github/workflows/ci-main-pull-request-stub.yml` workflow configuration to improve automation and security scanning. The most important changes include updating the stub version, enabling BlackDuck SCA scanning, and making the workflow more dynamic and descriptive for project-specific and language-specific settings.

**Versioning and Configuration Updates:**

* Bumped the `STUB_VERSION` environment variable from `"1.0.4"` to `"1.0.5"` to reflect the latest changes in the workflow.

**Security and Quality Scans:**

* Enabled `perform-blackduck-sca-scan` by default to ensure BlackDuck SCA scanning is performed as part of the workflow.
* Set `perform-docker-scan` to `false` to explicitly control Docker image scanning, clarifying intent for future changes.

**Project and Language Dynamism:**

* Changed `polaris-project-name` to use the repository name dynamically with `${{ github.event.repository.name }}` for more flexible project identification.
* Added `language: 'ruby'` to specify the primary programming language for build and SonarQube analysis, improving accuracy of language-specific checks.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
